### PR TITLE
rotations should be a int

### DIFF
--- a/screw_maker.py
+++ b/screw_maker.py
@@ -4028,7 +4028,7 @@ class Screw(object):
     
     #rotations = int(rots)-1
     halfrots_int = int(halfrots)
-    rotations = (halfrots_int / 2)-1
+    rotations = (halfrots_int // 2)-1
     if halfrots_int % 2 == 1:
       #FreeCAD.Console.PrintMessage("got half turn: " + str(halfrots_int) + "\n")
       halfturn = True


### PR DESCRIPTION
Came accross the following error with FreeCAD 0.18 and python 3.6.7.

```
Traceback (most recent call last):
  File "/home/chris/.FreeCAD/Mod/fasteners/FastenersCmd.py", line 121, in execute
    s = screwMaker.createFastener(fp.type, d, l, threadType, True)
  File "/home/chris/.FreeCAD/Mod/fasteners/ScrewMaker.py", line 264, in createFastener
    return self.createScrew(type, diam, len, threadType, shapeOnly)
  File "/home/chris/.FreeCAD/Mod/fasteners/screw_maker.py", line 2204, in createScrew
    screw = self.makeIso4762(ST_text, ND_text,l)
  File "/home/chris/.FreeCAD/Mod/fasteners/screw_maker.py", line 3780, in makeIso4762
    rthread = self.makeShellthread(dia, P, halfturns, True, offSet)
  File "/home/chris/.FreeCAD/Mod/fasteners/screw_maker.py", line 4098, in makeShellthread
    for i in range(rotations-2, rotations, 1):
<class 'TypeError'>: 'float' object cannot be interpreted as an integer
```

Making the devision returing an integer fixes this.