### PR TITLE
Do not delete dict items while iterating over keys

### DIFF
--- a/FastenerBase.py
+++ b/FastenerBase.py
@@ -164,7 +164,7 @@ def FSGetKey(*args):
   
 # removes all cached fasteners with real thread
 def FSCacheRemoveThreaded():
-  for key in FSCache.keys():
+  for key in list(FSCache.keys()):
     if key.endswith('|real'):
       FreeCAD.Console.PrintLog("Removing cached shape: " + key + "\n")
       del FSCache[key]


### PR DESCRIPTION
Convert keys() return value to list to make sure that it is not a
reference (e.g. DictView). Fixes:

RuntimeError: dictionary changed size during iteration