### PR TITLE
group fastenersWB commands as seperate toolbars by default

### DIFF
--- a/FSprefs.ui
+++ b/FSprefs.ui
@@ -57,7 +57,7 @@
            <string>Method of icon grouping</string>
           </property>
           <property name="currentIndex">
-           <number>0</number>
+           <number>1</number>
           </property>
           <property name="prefEntry" stdset="0">
            <string>ScrewToolbarGroupMode</string>


### PR DESCRIPTION
per [this forum post](https://forum.freecadweb.org/viewtopic.php?f=8&t=11429&start=280#p528028)

For users working on UI improvements, grouping all the 'add fastener' buttons in one toolbar tends to cause problems. 
![](https://forum.freecadweb.org/download/file.php?id=162745)

We already have the ability to split commands to multiple toolbars via a preferences setting. This PR makes the 'Separate Toolbars' option the default for new installations.