### PR TITLE
fix link out-of-scope warning for attached fasteners

### DIFF
--- a/FSNuts.py
+++ b/FSNuts.py
@@ -128,7 +128,7 @@ class FSHexNutObject(FSBaseObject):
     except:
       baseobj = None
       shape = None
-   
+    self.updateProps(obj)
     if (not (hasattr(self,'diameter')) or self.diameter != fp.diameter):
       if fp.diameter == 'Auto':
         d = FastenerBase.FSAutoDiameterM(shape, MHexNutTable, -1)

--- a/FastenerBase.py
+++ b/FastenerBase.py
@@ -37,13 +37,13 @@ class FSBaseObject:
   def __init__(self, obj, attachTo):
     obj.addProperty("App::PropertyDistance","offset","Parameters","Offset from surface").offset = 0.0
     obj.addProperty("App::PropertyBool", "invert", "Parameters", "Invert screw direction").invert = False
-    obj.addProperty("App::PropertyLinkSubGlobal", "baseObject", "Parameters", "Base object").baseObject = attachTo
+    obj.addProperty("App::PropertyXLinkSub", "baseObject", "Parameters", "Base object").baseObject = attachTo
 
   def updateProps(self, obj):
-    if obj.getTypeIdOfProperty("baseObject") == "App::PropertyLinkSub":
+    if obj.getTypeIdOfProperty("baseObject") != "App::PropertyXLinkSub":
       linkedObj = obj.baseObject
       obj.removeProperty("baseObject")
-      obj.addProperty("App::PropertyLinkSubGlobal", "baseObject", "Parameters", "Base object").baseObject = linkedObj
+      obj.addProperty("App::PropertyXLinkSub", "baseObject", "Parameters", "Base object").baseObject = linkedObj
 
     
 class FSGroupCommand:

--- a/FastenerBase.py
+++ b/FastenerBase.py
@@ -37,7 +37,14 @@ class FSBaseObject:
   def __init__(self, obj, attachTo):
     obj.addProperty("App::PropertyDistance","offset","Parameters","Offset from surface").offset = 0.0
     obj.addProperty("App::PropertyBool", "invert", "Parameters", "Invert screw direction").invert = False
-    obj.addProperty("App::PropertyLinkSub", "baseObject", "Parameters", "Base object").baseObject = attachTo
+    obj.addProperty("App::PropertyLinkSubGlobal", "baseObject", "Parameters", "Base object").baseObject = attachTo
+
+  def updateProps(self, obj):
+    if obj.getTypeIdOfProperty("baseObject") == "App::PropertyLinkSub":
+      linkedObj = obj.baseObject
+      obj.removeProperty("baseObject")
+      obj.addProperty("App::PropertyLinkSubGlobal", "baseObject", "Parameters", "Base object").baseObject = linkedObj
+
     
 class FSGroupCommand:
     def __init__(self, cmds, menuText, toolTip):

--- a/FastenersCmd.py
+++ b/FastenersCmd.py
@@ -63,6 +63,7 @@ class FSScrewObject(FSBaseObject):
       return inpstr
 
   def VerifyMissingAttrs(self, obj, diameter):
+    self.updateProps(obj)
     if not (hasattr(obj,'matchOuter')):
       obj.addProperty("App::PropertyBool", "matchOuter", "Parameters", "Match outer thread diameter").matchOuter = FastenerBase.FSMatchOuter
     if (self.itemText == "Screw" and  not hasattr(obj, 'lengthCustom')):
@@ -427,6 +428,7 @@ class FSScrewRodObject(FSBaseObject):
     obj.Proxy = self
  
   def VerifyMissingAttrs(self, obj):
+    self.updateProps(obj)
     if not (hasattr(obj,'matchOuter')):
       obj.addProperty("App::PropertyBool", "matchOuter", "Parameters", "Match outer thread diameter").matchOuter = FastenerBase.FSMatchOuter
     # for old objects from before custom diameter and pitch were implimented
@@ -568,6 +570,7 @@ class FSScrewDieObject(FSBaseObject):
     obj.Proxy = self
  
   def VerifyMissingAttrs(self, obj):
+    self.updateProps(obj)
     if not (hasattr(obj,'matchOuter')):
       obj.addProperty("App::PropertyBool", "matchOuter", "Parameters", "Match outer thread diameter").matchOuter = FastenerBase.FSMatchOuter
     # for old objects from before custom diameter and pitch were implimented
@@ -712,6 +715,7 @@ class FSThreadedRodObject(FSBaseObject):
     obj.Proxy = self
  
   def VerifyMissingAttrs(self, obj):
+    self.updateProps(obj)
     if not (hasattr(obj,'matchOuter')):
       obj.addProperty("App::PropertyBool", "matchOuter", "Parameters", "Match outer thread diameter").matchOuter = FastenerBase.FSMatchOuter
     # for old objects from before custom diameter and pitch were implimented

--- a/PEMInserts.py
+++ b/PEMInserts.py
@@ -154,7 +154,7 @@ class FSPressNutObject(FSBaseObject):
     except:
       baseobj = None
       shape = None
-   
+    self.updateProps(fp)
     if (not (hasattr(self,'diameter')) or self.diameter != fp.diameter or self.tcode != fp.tcode):
       if fp.diameter == 'Auto':
         d = FastenerBase.FSAutoDiameterM(shape, CLSPEMTable, 1)
@@ -375,7 +375,7 @@ class FSStandOffObject(FSBaseObject):
     except:
       baseobj = None
       shape = None
-   
+    self.updateProps(fp)
     if (not (hasattr(self,'diameter')) or self.diameter != fp.diameter or self.length != fp.length or self.blind != fp.blind):
       diameterchange = False      
       if not (hasattr(self,'diameter')) or self.diameter != fp.diameter:
@@ -548,7 +548,7 @@ class FSStudObject(FSBaseObject):
     except:
       baseobj = None
       shape = None
-   
+    self.updateProps(fp)
     if (not (hasattr(self,'diameter')) or self.diameter != fp.diameter or self.length != fp.length):
       diameterchange = False      
       if not (hasattr(self,'diameter')) or self.diameter != fp.diameter:
@@ -773,6 +773,7 @@ class FSPcbStandOffObject(FSBaseObject):
     obj.Proxy = self
 
   def VerifyMissingAttrs(self, obj, diam, width):
+    self.updateProps(obj)
     if (not hasattr(obj, 'lengthCustom')):
       slens = psGetAllLengths(PSMTable, PSLengths ,diam, width)
       if (hasattr(obj, 'length')):
@@ -992,7 +993,7 @@ class FSPcbSpacerObject(FSBaseObject):
     except:
       baseobj = None
       shape = None
-    
+    self.updateProps(fp)
     if (not (hasattr(self,'diameter')) or self.diameter != fp.diameter or self.width != fp.width or self.length != fp.length):
       diameterchange = False      
       if not (hasattr(self,'diameter')) or self.diameter != fp.diameter:


### PR DESCRIPTION
possibly/partially addresses #90 

currently, attached fasteners produce an error message every time they are recomputed
e.g.: `<App> GeoFeatureGroupExtension.cpp(577): t1#Screw.baseObject(links to t1#Body) is out of scope:t1#Part vs. <global>
`

The fix is to use `PropertyLinkSubGlobal` instead of `PropertyLinkSub`. This PR also updates fasteners in existing documents. (The error msg shows up one final time during the update process) 