### PR TITLE
Refactor makeShellthread

### DIFF
--- a/screw_maker.py
+++ b/screw_maker.py
@@ -1916,7 +1916,7 @@ class Screw(object):
        b = b0
     if l< b0:
        b = l - 2*P
-    elif (SType != 'ASME18.2.1.8'):
+    elif (SType != 'ASMEB18.2.1.8'):
        if l<= 125.0:
           b = b1
        else:


### PR DESCRIPTION
to address #103 

We currently can't reliably generate modeled threads for many inch fasteners. I decided to completely rewrite `makeShellthread` to make it more robust. The rewrite ensures that the top open part of the shell it returns always has the correct circular shape, among other minor optimizations:

![image](https://user-images.githubusercontent.com/37948669/141402588-0bfaece6-8b2a-4239-a06a-731d917aad92.png)

The new code uses more solid operations, but calculation time seems to be essentially the same.

I also ended up writing a hacky sort of unit test script to check thread generation behavior. 
I was able to use this script to confirm that the new code doesn't return OCC errors, and more reliably generate watertight solid geometry.

``` python
# run as a macro
# WARNING: this script tends to use system resources heavily, and slows the GUI to a crawl
import FreeCAD
import FreeCADGui

def runTests():
    FreeCADGui.activateWorkbench("FastenersWorkbench")
    doc = FreeCAD.newDocument()
    # make sure a freecad document is available
    if not doc:
        raise RuntimeError("Could not open a FreeCAD document. Aborting...")
    # create a fastener to get started
    FreeCADGui.runCommand('Hexhead',0)
    ScrewObj = doc.Objects[0]
    print("test setup initialized")
    # check that each available fastener generates properly
    for type in ScrewObj.getEnumerationsOfProperty('type'):
        ScrewObj.thread = False
        ScrewObj.type = type
        doc.recompute()
        length_list = ScrewObj.getEnumerationsOfProperty('length')
        for l in [length_list[0],length_list[-2]]:
            ScrewObj.length = l
            doc.recompute()
            if ScrewObj.Shape.isValid():
                print(f"{type} - {l} - nothread - test OK")
            else:
                print(f"{type} - {l} - nothread - test failed")
            ScrewObj.thread = True
            doc.recompute()
            if ScrewObj.Shape.isValid():
                print(f"{type} - {l} - realthread - test OK")
            else:
                print(f"{type} - {l} - realthread - test failed")
            ScrewObj.thread = False

if __name__ == "__main__":
    runTests()


```
PR also includes one random typo fix in `makeEN1662_2`