### PR TITLE
use 3D print scaling w. thread cutting tools (#101)

### DIFF
--- a/FastenersCmd.py
+++ b/FastenersCmd.py
@@ -47,7 +47,6 @@ class FSScrewObject(FSBaseObject):
     self.length = ''
     self.customlen = -1
     #self.Proxy = obj.Name
-    
     obj.addProperty("App::PropertyEnumeration","type","Parameters","Screw type").type = screwMaker.GetAllTypes(self.itemText)
     obj.type = type
     obj.addProperty("App::PropertyEnumeration","diameter","Parameters","Screw diameter standard").diameter = diameters
@@ -418,8 +417,6 @@ class FSScrewRodObject(FSBaseObject):
     self.type = typeStr
     diameters = screwMaker.GetAllDiams(self.type) + ["Custom"]
     diameters.insert(0, 'Auto')
-    #self.Proxy = obj.Name
-    
     obj.addProperty("App::PropertyEnumeration","diameter","Parameters","Screw diameter standard").diameter = diameters
     obj.addProperty("App::PropertyLength","diameterCustom","Parameters","Screw major diameter custom").diameterCustom = 6
     obj.addProperty("App::PropertyLength","pitchCustom","Parameters","Screw pitch custom").pitchCustom = 1.0
@@ -479,16 +476,14 @@ class FSScrewRodObject(FSBaseObject):
       p = fp.pitchCustom.Value
     else:
       p = None
-      
     screwMaker.updateFastenerParameters()  
-
     threadType = 'simple'
     if hasattr(fp,'thread') and fp.thread:
       threadType = 'real'
-    #s = screw_maker.Ui_ScrewMaker.
-    s_obj = ScrewMaker.Screw()
-    s_obj.setThreadType(threadType)
-    s = s_obj.makeScrewTap(self.type,d,l,p,d_custom)
+    # since we are bypassing the createScrew() method, we must set
+    # the rThread parameter manually
+    screwMaker.rThread = (threadType == 'real')
+    s = screwMaker.makeScrewTap(self.type,d,l,p,d_custom)
 
     self.diameter = fp.diameter
     self.length = l
@@ -627,11 +622,10 @@ class FSScrewDieObject(FSBaseObject):
     threadType = 'simple'
     if hasattr(fp,'thread') and fp.thread:
       threadType = 'real'
-    #s = screw_maker.Ui_ScrewMaker.
-    s_obj = ScrewMaker.Screw()
-    s_obj.setThreadType(threadType)
-    s = s_obj.makeScrewDie(self.type,d,l,p,d_custom)
-
+    # since we are bypassing the createScrew() method, we must set
+    # the rThread parameter manually
+    screwMaker.rThread = (threadType == 'real')
+    s = screwMaker.makeScrewDie(self.type,d,l,p,d_custom)
     self.diameter = fp.diameter
     self.length = l
     self.matchOuter = fp.matchOuter
@@ -772,10 +766,10 @@ class FSThreadedRodObject(FSBaseObject):
     threadType = 'simple'
     if hasattr(fp,'thread') and fp.thread:
       threadType = 'real'
-    #s = screw_maker.Ui_ScrewMaker.
-    s_obj = ScrewMaker.Screw()
-    s_obj.setThreadType(threadType)
-    s = s_obj.makeThreadedRod(self.type,d,l,p,d_custom)
+    # since we are bypassing the createScrew() method, we must set
+    # the rThread parameter manually
+    screwMaker.rThread = (threadType == 'real')
+    s = screwMaker.makeThreadedRod(self.type,d,l,p,d_custom)
 
     self.diameter = fp.diameter
     self.length = l

--- a/screw_maker.py
+++ b/screw_maker.py
@@ -3784,19 +3784,19 @@ class Screw(object):
   # make DIN 967 cross recessed pan head Screw with collar
   def makeScrewTap(self, SType = "ScrewTap", ThreadType ='M6',l=25.0, customPitch=None, customDia=None):
     if ThreadType != "Custom":
-      dia = self.getDia(ThreadType, False)
+      dia = self.getDia(ThreadType, True)
       if SType == "ScrewTap":
         P, tunIn, tunEx  = FsData["tuningTable"][ThreadType]
       elif SType == "ScrewTapInch":
         P = FsData["asmeb18.3.1adef"][ThreadType][0]
     else: # custom pitch and diameter
       P = customPitch
-      dia = customDia
+      if self.sm3DPrintMode:
+        dia = self.smNutThrScaleA * dia + self.smNutThrScaleB
+      else:
+        dia = customDia
     residue, turns = math.modf((l)/P)
     turns += 1.0
-    #FreeCAD.Console.PrintMessage("ScrewTap residue: " + str(residue) + " turns: " + str(turns) + "\n")
-
-
     if self.rThread:
       screwTap = self.makeInnerThread_2(dia, P, int(turns), None, 0.0)
       screwTap.translate(Base.Vector(0.0, 0.0,(1-residue)*P))
@@ -3830,7 +3830,10 @@ class Screw(object):
         P = FsData["asmeb18.3.1adef"][ThreadType][0]
     else: # custom pitch and diameter
       P = customPitch
-      dia = customDia
+      if self.sm3DPrintMode:
+         dia = self.smScrewThrScaleA * dia + self.smScrewThrScaleB
+      else:
+        dia = customDia 
     if self.rThread:
       cutDia = dia*0.75
     else:
@@ -3838,7 +3841,6 @@ class Screw(object):
     refpoint = Base.Vector(0,0,-1*l)
     screwDie = Part.makeCylinder(dia*1.1/2,l,refpoint)
     screwDie = screwDie.cut(Part.makeCylinder(cutDia/2,l,refpoint))
-    #screwDie = screwDie.translate(Base.Vector(0,0,-1*l))
     if self.rThread:
       residue, turns = math.modf((l)/P)
       turns += 2.0
@@ -3867,7 +3869,10 @@ class Screw(object):
         P = FsData["asmeb18.3.1adef"][ThreadType][0]
     else: # custom pitch and diameter
       P = customPitch
-      dia = customDia
+      if self.sm3DPrintMode:
+         dia = self.smScrewThrScaleA * dia + self.smScrewThrScaleB
+      else:
+        dia = customDia
     dia = dia*1.01
     cham = P
     p0 = Base.Vector(0,0,0)
@@ -3904,7 +3909,6 @@ class Screw(object):
       thread_shell = Part.Shell(thr_faces)
       thread_solid = Part.Solid(thread_shell)
       thread_solid.translate(Base.Vector(0,0,2*P))
-      #Part.show(thread_solid)
       screw = screw.common(thread_solid)
     return screw
 


### PR DESCRIPTION
Fixes some mistakes I made when I added custom sizing options to the thread-cutting tools.
Screwtap, Screwdie, and threaded rod objs now respect 3D print scaling settings.

measuring in a sketch to confirm that scaling is occurring on an M6 screwtap:
![image](https://user-images.githubusercontent.com/37948669/141597628-c1980270-1548-473e-b7f9-d1ef4190bd11.png)
