### PR TITLE
FS: change default ScrewToolbarGroupMode

### DIFF
--- a/FSprefs.ui
+++ b/FSprefs.ui
@@ -59,7 +59,7 @@
           <property name="currentIndex">
            <number>1</number>
           </property>
-          <property name="prefEntry" stdset="0">
+          <property name="prefEntry" stdset="1">
            <string>ScrewToolbarGroupMode</string>
           </property>
           <property name="prefPath" stdset="0">

--- a/FastenerBase.py
+++ b/FastenerBase.py
@@ -68,7 +68,7 @@ class FSGroupCommand:
 DropButtonSupported = int(FreeCAD.Version()[1]) > 15  # and  int(FreeCAD.Version()[2].split()[0]) >= 5165
 RadioButtonSupported = int(FreeCAD.Version()[1]) > 15  # and  int(FreeCAD.Version()[2].split()[0]) >= 5560
 FSParam = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Fasteners")
-GroupButtonMode = FSParam.GetInt("ScrewToolbarGroupMode", 0)  # 0 = nine, 1 = separate toolbar 2 = drop down buttons
+GroupButtonMode = FSParam.GetInt("ScrewToolbarGroupMode", 1)  # 0 = none, 1 = separate toolbar 2 = drop down buttons
 if GroupButtonMode == 2 and not DropButtonSupported:
     GroupButtonMode = 1
 


### PR DESCRIPTION
Since the default menu and toolbar are quite crowded it is better to make `ScrewToolbarGroupMode=1` the default.

Forum topic:
https://forum.freecadweb.org/viewtopic.php?f=8&t=67503&p=584072#p584072

Note that I have not updated package.xml.