### PR TITLE
Improve BOM generation

### DIFF
--- a/FastenerBase.py
+++ b/FastenerBase.py
@@ -144,6 +144,22 @@ def FSAddItemsToType(typeName, item):
 
 # common helpers
 
+def FSScrewStr(obj):
+    '''Return the textual representation of the screw diameter x length
+    + optional handedness ([M]<dia>x<len>[LH]), also accounting for
+    custom size properties'''
+    dia = obj.diameter if obj.diameter != 'Custom' else obj.diameterCustom
+    if isinstance(dia, FreeCAD.Units.Quantity):
+        dia = str(float(dia.Value)).rstrip('0').rstrip('.')
+    length = obj.length if obj.length != 'Custom' else obj.lengthCustom
+    if isinstance(length, FreeCAD.Units.Quantity):
+        length = str(float(length.Value)).rstrip('0').rstrip('.')
+    desc = dia + "x" + length
+    if obj.leftHanded:
+        desc += 'LH'
+    return desc
+
+
 # show traceback of system error
 def FSShowError():
     global lastErr
@@ -809,12 +825,7 @@ class FSMakeBomCommand:
             self.fastenerDB[fastener] = cnt
 
     def AddScrew(self, obj, cnt):
-        length = obj.length
-        if length == 'Custom':
-            length = str(float(obj.lengthCustom)).rstrip('0').rstrip('.')
-        desc = obj.type + " Screw " + obj.diameter + "x" + length
-        if obj.leftHanded:
-            desc += 'LH'
+        desc = obj.type + " Screw " + FSScrewStr(obj)
         self.AddFastener(desc, cnt)
 
     def AddNut(self, obj, cnt):

--- a/FastenerBase.py
+++ b/FastenerBase.py
@@ -827,13 +827,6 @@ class FSMakeBomCommand:
     def AddWasher(self, obj, cnt):
         self.AddFastener(obj.type + " Washer " + obj.diameter, cnt)
 
-    def AddScrewTap(self, obj, cnt):
-        length = str(float(obj.length)).rstrip('0').rstrip('.')
-        desc = "ScrewTap " + obj.diameter + "x" + length
-        if obj.leftHanded:
-            desc += 'LH'
-        self.AddFastener(desc, cnt)
-
     def AddPressNut(self, obj, cnt):
         self.AddFastener("PEM PressNut " + obj.diameter + "-" + obj.tcode, cnt)
 

--- a/FastenerBase.py
+++ b/FastenerBase.py
@@ -838,6 +838,10 @@ class FSMakeBomCommand:
     def AddWasher(self, obj, cnt):
         self.AddFastener(obj.type + " Washer " + obj.diameter, cnt)
 
+    def AddThreadedRod(self, obj, cnt):
+        desc = "Threaded Rod " + FSScrewStr(obj)
+        self.AddFastener(desc, cnt)
+
     def AddPressNut(self, obj, cnt):
         self.AddFastener("PEM PressNut " + obj.diameter + "-" + obj.tcode, cnt)
 


### PR DESCRIPTION
- Remove ScrewTap from the BOM (as discussed in #139)
- Add ThreadedRod instead, which was missing.

This PR adds a new FSScrewStr utility function to generate the descriptive [M]\<dia>x\<len>[LH] output to avoid duplication that handles the various combination of properties we have around.

This turns descriptions such as "Screw Customx12.2 mmLH" to "Screw 6x12.2LH" (as one extreme example I spotted).

The units in the string are omitted when using custom lengths and diameters, and will follow the units as configured in freecad. For a metric system this results in more-or-less what we want.

This function should also be used to generate the descriptive labels in the tree, as I spotted at least 4 cases in my previous PR where this is done by copy-pasting and incompletely. I will probably do so in another PR.