### PR TITLE
Fix typo in makeIso4032

### DIFF
--- a/screw_maker.py
+++ b/screw_maker.py
@@ -3716,8 +3716,6 @@ class Screw:
                 nutShell = Part.Shell(nutFaces)
                 nut = Part.Solid(nutShell)
                 # Part.show(nutShell)
-                
-        self.makeDin517(ThreadType)
         return nut
 
     # EN 1661 Hexagon nuts with flange


### PR DESCRIPTION
... that tried to call a function that did not exist,
breaking all hexagonal nuts (introduced in 1461d23541a9d5f7d9e7bd0da486ba4f624b5184)