### PR TITLE
Optimization of the FSScrewCommandTable.

### DIFF
--- a/FastenersCmd.py
+++ b/FastenersCmd.py
@@ -66,111 +66,123 @@ PEMStandoffParameters = {"type", "diameter", "matchOuter", "thread", "leftHanded
 FastenerAttribs = ['type', 'diameter', 'thread', 'leftHanded', 'matchOuter', 'length', 'lengthCustom', 'width', 
             'diameterCustom', 'pitchCustom', 'tcode', 'blind', 'screwLength']
 
+# Names of fasteners groups translated once before FSScrewCommandTable created.
+# For make FSScrewCommandTable more compact and readable
+HexHeadGroup = translate("FastenerCmd", "Hex head")
+HexagonSocketGroup = translate("FastenerCmd", "Hexagon socket")
+HexalobularSocketGroup = translate("FastenerCmd", "Hexalobular socket")
+SlottedGroup = translate("FastenerCmd", "Slotted")
+HCrossGroup = translate("FastenerCmd", "H cross")
+NutGroup = translate("FastenerCmd", "Nut")
+WasherGroup = translate("FastenerCmd", "Washer")
+OtherHeadGroup = translate("FastenerCmd", "Other head")
+ThreadedRodGroup = translate("FastenerCmd", "ThreadedRod")
+PEMInsertsGroup = translate("FastenerCmd", "PEM Inserts")
 
 CMD_HELP = 0
 CMD_GROUP = 1
 CMD_PARAMETER_GRP = 2
 FSScrewCommandTable = {
     # type:     help,                      group,      parameter-group
-    "ISO4017": (translate("FastenerCmd", "ISO 4017 Hex head screw"), translate("FastenerCmd", "Hex head"), ScrewParametersLC),
-    "ISO4014": (translate("FastenerCmd", "ISO 4014 Hex head bolt"), translate("FastenerCmd", "Hex head"), ScrewParametersLC),
-    "EN1662": (translate("FastenerCmd", "EN 1662 Hexagon bolt with flange, small series"), translate("FastenerCmd", "Hex head"), ScrewParametersLC),
-    "EN1665": (translate("FastenerCmd", "EN 1665 Hexagon bolt with flange, heavy series"), translate("FastenerCmd", "Hex head"), ScrewParametersLC),
-    "DIN571": (translate("FastenerCmd", "DIN 571 Hex head wood screw"), translate("FastenerCmd", "Hex head"), ScrewParametersLC),
+    "ISO4017": (translate("FastenerCmd", "ISO 4017 Hex head screw"), HexHeadGroup, ScrewParametersLC),
+    "ISO4014": (translate("FastenerCmd", "ISO 4014 Hex head bolt"), HexHeadGroup, ScrewParametersLC),
+    "EN1662": (translate("FastenerCmd", "EN 1662 Hexagon bolt with flange, small series"), HexHeadGroup, ScrewParametersLC),
+    "EN1665": (translate("FastenerCmd", "EN 1665 Hexagon bolt with flange, heavy series"), HexHeadGroup, ScrewParametersLC),
+    "DIN571": (translate("FastenerCmd", "DIN 571 Hex head wood screw"), HexHeadGroup, ScrewParametersLC),
 
-    "ISO4762": (translate("FastenerCmd", "ISO4762 Hexagon socket head cap screw"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "DIN7984": (translate("FastenerCmd", "DIN 7984 Hexagon socket head cap screws with low head"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "DIN6912": (translate("FastenerCmd", "DIN 6912 Hexagon socket head cap screws with low head with centre"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ISO7380-1": (translate("FastenerCmd", "ISO 7380 Hexagon socket button head screw"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ISO7380-2": (translate("FastenerCmd", "ISO 7380 Hexagon socket button head screws with collar"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ISO10642": (translate("FastenerCmd", "ISO 10642 Hexagon socket countersunk head screw"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ISO7379": (translate("FastenerCmd", "ISO 7379 Hexagon socket head shoulder screw"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ISO4026": (translate("FastenerCmd", "ISO 4026 Hexagon socket set screws with flat point"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ISO4027": (translate("FastenerCmd", "ISO 4027 Hexagon socket set screws with cone point"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ISO4028": (translate("FastenerCmd", "ISO 4028 Hexagon socket set screws with dog point"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ISO4029": (translate("FastenerCmd", "ISO 4029 Hexagon socket set screws with cup point"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
+    "ISO4762": (translate("FastenerCmd", "ISO4762 Hexagon socket head cap screw"), HexagonSocketGroup, ScrewParametersLC),
+    "DIN7984": (translate("FastenerCmd", "DIN 7984 Hexagon socket head cap screws with low head"), HexagonSocketGroup, ScrewParametersLC),
+    "DIN6912": (translate("FastenerCmd", "DIN 6912 Hexagon socket head cap screws with low head with centre"), HexagonSocketGroup, ScrewParametersLC),
+    "ISO7380-1": (translate("FastenerCmd", "ISO 7380 Hexagon socket button head screw"), HexagonSocketGroup, ScrewParametersLC),
+    "ISO7380-2": (translate("FastenerCmd", "ISO 7380 Hexagon socket button head screws with collar"), HexagonSocketGroup, ScrewParametersLC),
+    "ISO10642": (translate("FastenerCmd", "ISO 10642 Hexagon socket countersunk head screw"), HexagonSocketGroup, ScrewParametersLC),
+    "ISO7379": (translate("FastenerCmd", "ISO 7379 Hexagon socket head shoulder screw"), HexagonSocketGroup, ScrewParametersLC),
+    "ISO4026": (translate("FastenerCmd", "ISO 4026 Hexagon socket set screws with flat point"), HexagonSocketGroup, ScrewParametersLC),
+    "ISO4027": (translate("FastenerCmd", "ISO 4027 Hexagon socket set screws with cone point"), HexagonSocketGroup, ScrewParametersLC),
+    "ISO4028": (translate("FastenerCmd", "ISO 4028 Hexagon socket set screws with dog point"), HexagonSocketGroup, ScrewParametersLC),
+    "ISO4029": (translate("FastenerCmd", "ISO 4029 Hexagon socket set screws with cup point"), HexagonSocketGroup, ScrewParametersLC),
 
-    "ISO14579": (translate("FastenerCmd", "ISO 14579 Hexalobular socket head cap screws"), translate("FastenerCmd", "Hexalobular socket"), ScrewParametersLC),
-    "ISO14580": (translate("FastenerCmd", "ISO 14580 Hexalobular socket cheese head screws"), translate("FastenerCmd", "Hexalobular socket"), ScrewParametersLC),
-#    "ISO14581": (translate("FastenerCmd", "ISO 14581 Hexalobular socket countersunk flat head screws"), translate("FastenerCmd", "Hexalobular socket"), ScrewParametersLC),
-    "ISO14582": (translate("FastenerCmd", "ISO 14582 Hexalobular socket countersunk head screws, high head"), translate("FastenerCmd", "Hexalobular socket"), ScrewParametersLC),
-    "ISO14583": (translate("FastenerCmd", "ISO 14583 Hexalobular socket pan head screws"), translate("FastenerCmd", "Hexalobular socket"), ScrewParametersLC),
-    "ISO14584": (translate("FastenerCmd", "ISO 14584 Hexalobular socket raised countersunk head screws"), translate("FastenerCmd", "Hexalobular socket"), ScrewParametersLC),
+    "ISO14579": (translate("FastenerCmd", "ISO 14579 Hexalobular socket head cap screws"), HexalobularSocketGroup, ScrewParametersLC),
+    "ISO14580": (translate("FastenerCmd", "ISO 14580 Hexalobular socket cheese head screws"), HexalobularSocketGroup, ScrewParametersLC),
+#    "ISO14581": (translate("FastenerCmd", "ISO 14581 Hexalobular socket countersunk flat head screws"), HexalobularSocketGroup, ScrewParametersLC),
+    "ISO14582": (translate("FastenerCmd", "ISO 14582 Hexalobular socket countersunk head screws, high head"), HexalobularSocketGroup, ScrewParametersLC),
+    "ISO14583": (translate("FastenerCmd", "ISO 14583 Hexalobular socket pan head screws"), HexalobularSocketGroup, ScrewParametersLC),
+    "ISO14584": (translate("FastenerCmd", "ISO 14584 Hexalobular socket raised countersunk head screws"), HexalobularSocketGroup, ScrewParametersLC),
 
-    "ISO2009": (translate("FastenerCmd", "ISO 2009 Slotted countersunk flat head screw"), translate("FastenerCmd", "Slotted"), ScrewParametersLC),
-    "ISO2010": (translate("FastenerCmd", "ISO 2010 Slotted raised countersunk head screw"), translate("FastenerCmd", "Slotted"), ScrewParametersLC),
-    "ISO1580": (translate("FastenerCmd", "ISO 1580 Slotted pan head screw"), translate("FastenerCmd", "Slotted"), ScrewParametersLC),
-    "ISO1207": (translate("FastenerCmd", "ISO 1207 Slotted cheese head screw"), translate("FastenerCmd", "Slotted"), ScrewParametersLC),
-    "DIN96":   (translate("FastenerCmd", "DIN 96 Slotted half round head wood screw"), translate("FastenerCmd", "Slotted"), ScrewParametersLC),
-    "GOST1144-1": (translate("FastenerCmd", "GOST 1144 (Type 1) Half — round head wood screw"), translate("FastenerCmd", "Slotted"), ScrewParametersLC),
-    "GOST1144-2": (translate("FastenerCmd", "GOST 1144 (Type 2) Half — round head wood screw"), translate("FastenerCmd", "Slotted"), ScrewParametersLC),
+    "ISO2009": (translate("FastenerCmd", "ISO 2009 Slotted countersunk flat head screw"), SlottedGroup, ScrewParametersLC),
+    "ISO2010": (translate("FastenerCmd", "ISO 2010 Slotted raised countersunk head screw"), SlottedGroup, ScrewParametersLC),
+    "ISO1580": (translate("FastenerCmd", "ISO 1580 Slotted pan head screw"), SlottedGroup, ScrewParametersLC),
+    "ISO1207": (translate("FastenerCmd", "ISO 1207 Slotted cheese head screw"), SlottedGroup, ScrewParametersLC),
+    "DIN96":   (translate("FastenerCmd", "DIN 96 Slotted half round head wood screw"), SlottedGroup, ScrewParametersLC),
+    "GOST1144-1": (translate("FastenerCmd", "GOST 1144 (Type 1) Half — round head wood screw"), SlottedGroup, ScrewParametersLC),
+    "GOST1144-2": (translate("FastenerCmd", "GOST 1144 (Type 2) Half — round head wood screw"), SlottedGroup, ScrewParametersLC),
             
-    "DIN967": (translate("FastenerCmd", "DIN 967 Cross recessed pan head screws with collar"), translate("FastenerCmd", "H cross"), ScrewParametersLC),
-    "ISO7045": (translate("FastenerCmd", "ISO 7045 Pan head screws type H cross recess"), translate("FastenerCmd", "H cross"), ScrewParametersLC),
-    "ISO7046": (translate("FastenerCmd", "ISO 7046 Countersunk flat head screws H cross r."), translate("FastenerCmd", "H cross"), ScrewParametersLC),
-    "ISO7047": (translate("FastenerCmd", "ISO 7047 Raised countersunk head screws H cross r."), translate("FastenerCmd", "H cross"), ScrewParametersLC),
-    "ISO7048": (translate("FastenerCmd", "ISO 7048 Cheese head screws with type H cross r."), translate("FastenerCmd", "H cross"), ScrewParametersLC),
+    "DIN967": (translate("FastenerCmd", "DIN 967 Cross recessed pan head screws with collar"), HCrossGroup, ScrewParametersLC),
+    "ISO7045": (translate("FastenerCmd", "ISO 7045 Pan head screws type H cross recess"), HCrossGroup, ScrewParametersLC),
+    "ISO7046": (translate("FastenerCmd", "ISO 7046 Countersunk flat head screws H cross r."), HCrossGroup, ScrewParametersLC),
+    "ISO7047": (translate("FastenerCmd", "ISO 7047 Raised countersunk head screws H cross r."), HCrossGroup, ScrewParametersLC),
+    "ISO7048": (translate("FastenerCmd", "ISO 7048 Cheese head screws with type H cross r."), HCrossGroup, ScrewParametersLC),
 
-    "ISO4032": (translate("FastenerCmd", "ISO 4032 Hexagon nuts, Style 1"), translate("FastenerCmd", "Nut"), NutParameters),
-    "ISO4033": (translate("FastenerCmd", "ISO 4033 Hexagon nuts, Style 2"), translate("FastenerCmd", "Nut"), NutParameters),
-    "ISO4035": (translate("FastenerCmd", "ISO 4035 Hexagon thin nuts, chamfered"), translate("FastenerCmd", "Nut"), NutParameters),
-#    "ISO4036": (translate("FastenerCmd", "ISO 4035 Hexagon thin nuts, unchamfered"), translate("FastenerCmd", "Nut"), NutParameters),
-    "EN1661": (translate("FastenerCmd", "EN 1661 Hexagon nuts with flange"), translate("FastenerCmd", "Nut"), NutParameters),
-    "DIN917": (translate("FastenerCmd", "DIN917 Cap nuts, thin style"), translate("FastenerCmd", "Nut"), NutParameters),
-    "DIN1587": (translate("FastenerCmd", "DIN 1587 Cap nuts"), translate("FastenerCmd", "Nut"), NutParameters),
-    "GOST11860-1": (translate("FastenerCmd", "GOST 11860 (Type 1) Cap nuts"), translate("FastenerCmd", "Nut"), NutParameters), 
-    "DIN557": (translate("FastenerCmd", "DIN 557 Square nuts"), translate("FastenerCmd", "Nut"), NutParameters),
-    "DIN562": (translate("FastenerCmd", "DIN 562 Square nuts"), translate("FastenerCmd", "Nut"), NutParameters),
-    "DIN985": (translate("FastenerCmd", "DIN 985 Nyloc nuts"), translate("FastenerCmd", "Nut"), NutParameters),
+    "ISO4032": (translate("FastenerCmd", "ISO 4032 Hexagon nuts, Style 1"), NutGroup, NutParameters),
+    "ISO4033": (translate("FastenerCmd", "ISO 4033 Hexagon nuts, Style 2"), NutGroup, NutParameters),
+    "ISO4035": (translate("FastenerCmd", "ISO 4035 Hexagon thin nuts, chamfered"), NutGroup, NutParameters),
+#    "ISO4036": (translate("FastenerCmd", "ISO 4035 Hexagon thin nuts, unchamfered"), NutGroup, NutParameters),
+    "EN1661": (translate("FastenerCmd", "EN 1661 Hexagon nuts with flange"), NutGroup, NutParameters),
+    "DIN917": (translate("FastenerCmd", "DIN917 Cap nuts, thin style"), NutGroup, NutParameters),
+    "DIN1587": (translate("FastenerCmd", "DIN 1587 Cap nuts"), NutGroup, NutParameters),
+    "GOST11860-1": (translate("FastenerCmd", "GOST 11860 (Type 1) Cap nuts"), NutGroup, NutParameters), 
+    "DIN557": (translate("FastenerCmd", "DIN 557 Square nuts"), NutGroup, NutParameters),
+    "DIN562": (translate("FastenerCmd", "DIN 562 Square nuts"), NutGroup, NutParameters),
+    "DIN985": (translate("FastenerCmd", "DIN 985 Nyloc nuts"), NutGroup, NutParameters),
 
-    "ISO7089": (translate("FastenerCmd", "ISO 7089 Washer"), translate("FastenerCmd", "Washer"), WasherParameters),
-    "ISO7090": (translate("FastenerCmd", "ISO 7090 Plain Washers, chamfered - Normal series"), translate("FastenerCmd", "Washer"), WasherParameters),
-#    "ISO7091": (translate("FastenerCmd", "ISO 7091 Plain washer - Normal series Product Grade C"), translate("FastenerCmd", "Washer"), WasherParameters),   # same as 7089??
-    "ISO7092": (translate("FastenerCmd", "ISO 7092 Plain washers - Small series"), translate("FastenerCmd", "Washer"), WasherParameters),
-    "ISO7093-1": (translate("FastenerCmd", "ISO 7093-1 Plain washers - Large series"), translate("FastenerCmd", "Washer"), WasherParameters),
-    "ISO7094": (translate("FastenerCmd", "ISO 7094 Plain washers - Extra large series"), translate("FastenerCmd", "Washer"), WasherParameters),
-    "NFE27-619": (translate("FastenerCmd", "NFE27-619 Countersunk washer"), translate("FastenerCmd", "Washer"), WasherParameters),
+    "ISO7089": (translate("FastenerCmd", "ISO 7089 Washer"), WasherGroup, WasherParameters),
+    "ISO7090": (translate("FastenerCmd", "ISO 7090 Plain Washers, chamfered - Normal series"), WasherGroup, WasherParameters),
+#    "ISO7091": (translate("FastenerCmd", "ISO 7091 Plain washer - Normal series Product Grade C"), WasherGroup, WasherParameters),   # same as 7089??
+    "ISO7092": (translate("FastenerCmd", "ISO 7092 Plain washers - Small series"), WasherGroup, WasherParameters),
+    "ISO7093-1": (translate("FastenerCmd", "ISO 7093-1 Plain washers - Large series"), WasherGroup, WasherParameters),
+    "ISO7094": (translate("FastenerCmd", "ISO 7094 Plain washers - Extra large series"), WasherGroup, WasherParameters),
+    "NFE27-619": (translate("FastenerCmd", "NFE27-619 Countersunk washer"), WasherGroup, WasherParameters),
 
 # Inch
 
-    "ASMEB18.2.1.6": (translate("FastenerCmd", "ASME B18.2.1 UNC Hex head screws"), translate("FastenerCmd", "Hex head"), ScrewParametersLC),
-    "ASMEB18.2.1.8": (translate("FastenerCmd", "ASME B18.2.1 UNC Hex head screws with flange"), translate("FastenerCmd", "Hex head"), ScrewParametersLC),
+    "ASMEB18.2.1.6": (translate("FastenerCmd", "ASME B18.2.1 UNC Hex head screws"), HexHeadGroup, ScrewParametersLC),
+    "ASMEB18.2.1.8": (translate("FastenerCmd", "ASME B18.2.1 UNC Hex head screws with flange"), HexHeadGroup, ScrewParametersLC),
 
-    "ASMEB18.3.1A": (translate("FastenerCmd", "ASME B18.3 UNC Hex socket head cap screws"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ASMEB18.3.1G": (translate("FastenerCmd", "ASME B18.3 UNC Hex socket head cap screws with low head"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ASMEB18.3.2": (translate("FastenerCmd", "ASME B18.3 UNC Hex socket countersunk head screws"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ASMEB18.3.3A": (translate("FastenerCmd", "ASME B18.3 UNC Hex socket button head screws"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ASMEB18.3.3B": (translate("FastenerCmd", "ASME B18.3 UNC Hex socket button head screws with flange"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ASMEB18.3.4": (translate("FastenerCmd", "ASME B18.3 UNC Hexagon socket head shoulder screws"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ASMEB18.3.5A": (translate("FastenerCmd", "ASME B18.3 UNC Hexagon socket set screws with flat point"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ASMEB18.3.5B": (translate("FastenerCmd", "ASME B18.3 UNC Hexagon socket set screws with cone point"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ASMEB18.3.5C": (translate("FastenerCmd", "ASME B18.3 UNC Hexagon socket set screws with dog point"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
-    "ASMEB18.3.5D": (translate("FastenerCmd", "ASME B18.3 UNC Hexagon socket set screws with cup point"), translate("FastenerCmd", "Hexagon socket"), ScrewParametersLC),
+    "ASMEB18.3.1A": (translate("FastenerCmd", "ASME B18.3 UNC Hex socket head cap screws"), HexagonSocketGroup, ScrewParametersLC),
+    "ASMEB18.3.1G": (translate("FastenerCmd", "ASME B18.3 UNC Hex socket head cap screws with low head"), HexagonSocketGroup, ScrewParametersLC),
+    "ASMEB18.3.2": (translate("FastenerCmd", "ASME B18.3 UNC Hex socket countersunk head screws"), HexagonSocketGroup, ScrewParametersLC),
+    "ASMEB18.3.3A": (translate("FastenerCmd", "ASME B18.3 UNC Hex socket button head screws"), HexagonSocketGroup, ScrewParametersLC),
+    "ASMEB18.3.3B": (translate("FastenerCmd", "ASME B18.3 UNC Hex socket button head screws with flange"), HexagonSocketGroup, ScrewParametersLC),
+    "ASMEB18.3.4": (translate("FastenerCmd", "ASME B18.3 UNC Hexagon socket head shoulder screws"), HexagonSocketGroup, ScrewParametersLC),
+    "ASMEB18.3.5A": (translate("FastenerCmd", "ASME B18.3 UNC Hexagon socket set screws with flat point"), HexagonSocketGroup, ScrewParametersLC),
+    "ASMEB18.3.5B": (translate("FastenerCmd", "ASME B18.3 UNC Hexagon socket set screws with cone point"), HexagonSocketGroup, ScrewParametersLC),
+    "ASMEB18.3.5C": (translate("FastenerCmd", "ASME B18.3 UNC Hexagon socket set screws with dog point"), HexagonSocketGroup, ScrewParametersLC),
+    "ASMEB18.3.5D": (translate("FastenerCmd", "ASME B18.3 UNC Hexagon socket set screws with cup point"), HexagonSocketGroup, ScrewParametersLC),
 
-    "ASMEB18.6.3.1A": (translate("FastenerCmd", "ASME B18.6.3 UNC slotted countersunk flat head screws"), translate("FastenerCmd", "Slotted"), ScrewParametersLC),
+    "ASMEB18.6.3.1A": (translate("FastenerCmd", "ASME B18.6.3 UNC slotted countersunk flat head screws"), SlottedGroup, ScrewParametersLC),
 
-    "ASMEB18.5.2": (translate("FastenerCmd", "ASME B18.5 UNC Round head square neck bolts"), translate("FastenerCmd", "Other head"), ScrewParametersLC),
+    "ASMEB18.5.2": (translate("FastenerCmd", "ASME B18.5 UNC Round head square neck bolts"), OtherHeadGroup, ScrewParametersLC),
 
-    "ASMEB18.2.2.1A": (translate("FastenerCmd", "ASME B18.2.2 UNC Machine screw nuts"), translate("FastenerCmd", "Nut"), NutParameters),
-    "ASMEB18.2.2.4A": (translate("FastenerCmd", "ASME B18.2.2 UNC Hexagon nuts"), translate("FastenerCmd", "Nut"), NutParameters),
-    "ASMEB18.2.2.4B": (translate("FastenerCmd", "ASME B18.2.2 UNC Hexagon thin nuts"), translate("FastenerCmd", "Nut"), NutParameters),
+    "ASMEB18.2.2.1A": (translate("FastenerCmd", "ASME B18.2.2 UNC Machine screw nuts"), NutGroup, NutParameters),
+    "ASMEB18.2.2.4A": (translate("FastenerCmd", "ASME B18.2.2 UNC Hexagon nuts"), NutGroup, NutParameters),
+    "ASMEB18.2.2.4B": (translate("FastenerCmd", "ASME B18.2.2 UNC Hexagon thin nuts"), NutGroup, NutParameters),
 
-    "ASMEB18.21.1.12A": (translate("FastenerCmd", "ASME B18.21.1 UN washers, narrow series"), translate("FastenerCmd", "Washer"), WasherParameters),
-    "ASMEB18.21.1.12B": (translate("FastenerCmd", "ASME B18.21.1 UN washers, regular series"), translate("FastenerCmd", "Washer"), WasherParameters),
-    "ASMEB18.21.1.12C": (translate("FastenerCmd", "ASME B18.21.1 UN washers, wide series"), translate("FastenerCmd", "Washer"), WasherParameters),
+    "ASMEB18.21.1.12A": (translate("FastenerCmd", "ASME B18.21.1 UN washers, narrow series"), WasherGroup, WasherParameters),
+    "ASMEB18.21.1.12B": (translate("FastenerCmd", "ASME B18.21.1 UN washers, regular series"), WasherGroup, WasherParameters),
+    "ASMEB18.21.1.12C": (translate("FastenerCmd", "ASME B18.21.1 UN washers, wide series"), WasherGroup, WasherParameters),
 
-    "ScrewTap": (translate("FastenerCmd", "Metric threaded rod for tapping holes"), translate("FastenerCmd", "ThreadedRod"), RodParameters),
-    "ScrewTapInch": (translate("FastenerCmd", "Inch threaded rod for tapping holes"), translate("FastenerCmd", "ThreadedRod"), RodParameters),
-    "ScrewDie": (translate("FastenerCmd", "Tool object to cut external metric threads"), translate("FastenerCmd", "ThreadedRod"), RodParameters),
-    "ScrewDieInch": (translate("FastenerCmd", "Tool object to cut external non-metric threads"), translate("FastenerCmd", "ThreadedRod"), RodParameters),
-    "ThreadedRod": (translate("FastenerCmd", "DIN 975 metric threaded rod"), translate("FastenerCmd", "ThreadedRod"), RodParameters),
-    "ThreadedRodInch": (translate("FastenerCmd", "UNC threaded rod"), translate("FastenerCmd", "ThreadedRod"), RodParameters),
-    "PEMPressNut": (translate("FastenerCmd", "PEM Self Clinching nut"), translate("FastenerCmd", "PEM Inserts"), PEMPressNutParameters),
-    "PEMStandoff": (translate("FastenerCmd", "PEM Self Clinching standoff"), translate("FastenerCmd", "PEM Inserts"), PEMStandoffParameters),
-    "PEMStud": (translate("FastenerCmd", "PEM Self Clinching stud"), translate("FastenerCmd", "PEM Inserts"), ScrewParameters),
-    "PCBStandoff": (translate("FastenerCmd", "Wurth WA-SSTII  PCB standoff"), translate("FastenerCmd", "PEM Inserts"), PCBStandoffParameters),
-    "PCBSpacer": (translate("FastenerCmd", "Wurth WA-SSTII PCB spacer"), translate("FastenerCmd", "PEM Inserts"), PCBSpacerParameters),
-    "IUTHeatInsert": (translate("FastenerCmd", "IUT[A/B/C] Heat Staked Metric Insert"), translate("FastenerCmd", "PEM Inserts"), NutParameters),
+    "ScrewTap": (translate("FastenerCmd", "Metric threaded rod for tapping holes"), ThreadedRodGroup, RodParameters),
+    "ScrewTapInch": (translate("FastenerCmd", "Inch threaded rod for tapping holes"), ThreadedRodGroup, RodParameters),
+    "ScrewDie": (translate("FastenerCmd", "Tool object to cut external metric threads"), ThreadedRodGroup, RodParameters),
+    "ScrewDieInch": (translate("FastenerCmd", "Tool object to cut external non-metric threads"), ThreadedRodGroup, RodParameters),
+    "ThreadedRod": (translate("FastenerCmd", "DIN 975 metric threaded rod"), ThreadedRodGroup, RodParameters),
+    "ThreadedRodInch": (translate("FastenerCmd", "UNC threaded rod"), ThreadedRodGroup, RodParameters),
+    "PEMPressNut": (translate("FastenerCmd", "PEM Self Clinching nut"), PEMInsertsGroup, PEMPressNutParameters),
+    "PEMStandoff": (translate("FastenerCmd", "PEM Self Clinching standoff"), PEMInsertsGroup, PEMStandoffParameters),
+    "PEMStud": (translate("FastenerCmd", "PEM Self Clinching stud"), PEMInsertsGroup, ScrewParameters),
+    "PCBStandoff": (translate("FastenerCmd", "Wurth WA-SSTII  PCB standoff"), PEMInsertsGroup, PCBStandoffParameters),
+    "PCBSpacer": (translate("FastenerCmd", "Wurth WA-SSTII PCB spacer"), PEMInsertsGroup, PCBSpacerParameters),
+    "IUTHeatInsert": (translate("FastenerCmd", "IUT[A/B/C] Heat Staked Metric Insert"), PEMInsertsGroup, NutParameters),
 }
 
 def GetParams(type):


### PR DESCRIPTION
The translation of groups is repeated when creating the command table.
In addition, it makes the command lines very long and inconveniently readable.

I propose the following solution:

The groups are translated once before the formation of the command table. 
This should increase the readability of the table. 
And generally have a positive impact on the development.
In addition, it will reduce the size of the FSScrewCommandTable code in bytes.