### PR TITLE
FastenersCmd.py: Convert from str when assigning lengthcustom property

### DIFF
--- a/FastenersCmd.py
+++ b/FastenersCmd.py
@@ -451,7 +451,7 @@ class FSScrewObject(FSBaseObject):
                     else:
                         fp.length = l
                         if hasattr(fp, 'lengthCustom'):
-                            fp.lengthCustom = l
+                            fp.lengthCustom = FastenerBase.LenStr2Num(l)
                 self.calc_len = l
         else:
             self.calc_len = None


### PR DESCRIPTION
the old behavior was to dump the length value (as string e.g.: "6mm", "3/4in") into the featurePython 'lengthCustom' property.
This mostly worked, but it would fail on length formatted like "1 3/4in".
So selecting some inch fasteners would cause the expression parser to throw a syntax error

One line fix.