### PR TITLE
Add GrammaticalTools.py

### DIFF
--- a/FastenersCmd.py
+++ b/FastenersCmd.py
@@ -606,10 +606,12 @@ class FSScrewCommand:
         self.TypeName = screwMaker.GetTypeName(type)
 
     def GetResources(self):
+        import GrammaticalTools
+        
         icon = os.path.join(iconPath, self.Type + '.svg')
         return {'Pixmap': icon,
                 # the name of a svg file available in the resources
-                'MenuText': translate("FastenerCmd", "Add ") + self.Help,
+                'MenuText': translate("FastenerCmd", "Add ") + GrammaticalTools.ToDativeCase(self.Help),
                 'ToolTip': self.Help}
 
     def Activated(self):

--- a/GrammaticalTools.py
+++ b/GrammaticalTools.py
@@ -3,13 +3,15 @@
 #
 #   Original code by:
 #   FreeCADTools 
+#   Updated by:
+#   EA32
 #
 ###############################################################################
 import FreeCADGui
 
 # Converts text to Dative case form for comptable with "Add " preffix
 # Used in FSScrewCommand class (FastnersCmd.py)
-# More information about Dative case at en.wikipedia.org/wiki/Dative_case
+# More information about Dative case at: en.wikipedia.org/wiki/Dative_case
 def ToDativeCase(s):
   if FreeCADGui.getLocale() == "Russian":
      #t = s
@@ -38,5 +40,27 @@ def ToDativeCase(s):
      s = s.replace("Ре", "ре")
      s = s.replace("Га", "га")
      s = s.replace("типа н", "типа Н")
+     #print("'Добавить "+t+"' -> 'Добавить "+s+"'")
+  return s
+  
+# Converts text to Singular form for comptable with "Add " preffix
+# Used in InitGui.py , more information about singular/plural forms at:
+# en.wikipedia.org/wiki/Grammatical_number#Singular_versus_plural
+def ToSingular(s):
+  if FreeCADGui.getLocale() == "Russian":
+     #t = s
+     s = s.lower()+" "
+     s = s.replace("бы ", "ба ")
+     s = s.replace("ки ", "ка ")
+     s = s.replace("ты ", "т ")
+     s = s.replace("рные ", "рное ")
+     s = s.replace("ые ", "ую ")
+     s = s.replace("ба ", "бу ")
+     s = s.replace("ты ", "т ")
+     s = s.replace("ка ", "ку ")
+     s = s.replace("ца ", "цо ")
+     s = s.replace("ими ", "ой ")
+     s = s.replace("ами ", "ой ")
+     s = s.replace("т-", "Т-")
      #print("'Добавить "+t+"' -> 'Добавить "+s+"'")
   return s

--- a/GrammaticalTools.py
+++ b/GrammaticalTools.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#   Original code by:
+#   FreeCADTools 
+#
+###############################################################################
+import FreeCADGui
+
+# Converts text to Dative case form for comptable with "Add " preffix
+# Used in FSScrewCommand class (FastnersCmd.py)
+# More information about Dative case at en.wikipedia.org/wiki/Dative_case
+def ToDativeCase(s):
+  if FreeCADGui.getLocale() == "Russian":
+     #t = s
+     s = s + " "
+     s = s.replace("ба ", "бу ") # шайба
+     s = s.replace("ба,", "бу,")
+     s = s.replace("ба-", "бу-")
+     s = s.replace("ка ", "ку ") # шпилька, гайка
+     s = s.replace("вая ", "вую ") # резьбовая
+     s = s.replace("аяся ", "уюся ") # самокотнрящаяся
+     s = s.replace("ская ", "скую ")
+     s = s.replace("ая серия", "ой серии") # крупная/нормальная/мелкая серия
+     s = s.replace("ная ", "ную ")
+     s = s.replace("ая,", "ую,") # резьбовая
+     s = s.replace("ая ", "ую ")
+     # lower case for all string instead abbriviatures like GOST, DIN, ISO etc.
+     s = s.replace("Ш", "ш")
+     s = s.replace("К", "к")
+     s = s.replace("В", "в")
+     s = s.replace("М", "м")
+     s = s.replace("П", "п")
+     s = s.replace("Д", "д")
+     s = s.replace("Б", "б")
+     s = s.replace("Н", "н")
+     s = s.replace("Осо", "осо")
+     s = s.replace("Ре", "ре")
+     s = s.replace("Га", "га")
+     s = s.replace("типа н", "типа Н")
+     #print("'Добавить "+t+"' -> 'Добавить "+s+"'")
+  return s

--- a/InitGui.py
+++ b/InitGui.py
@@ -45,6 +45,7 @@ class FastenersWorkbench(FreeCADGui.Workbench):
         import FastenersCmd
         import CountersunkHoles
         import FSChangeParams
+        import GrammaticalTools
 
         self.list = []
         cmdlist = FastenerBase.FSGetCommands("command")
@@ -63,7 +64,7 @@ class FastenersWorkbench(FreeCADGui.Workbench):
                 self.appendMenu(
                     [
                         translate("InitGui", "Fasteners"),
-                        translate("InitGui", "Add ") + cmd[2],
+                        translate("InitGui", "Add ") + GrammaticalTools.ToSingular(cmd[2]),
                     ],
                     cmd[1],
                 )
@@ -105,6 +106,5 @@ class FastenersWorkbench(FreeCADGui.Workbench):
     def GetClassName(self):
         # this function is mandatory if this is a full python workbench
         return "Gui::PythonWorkbench"
-
 
 FreeCADGui.addWorkbench(FastenersWorkbench())


### PR DESCRIPTION
GrammaticalTools.py is a special file that contains tools for converting text into the correct form. The English language is contain limited variants of grammatical cases, so simply adding "Add" at the beginning of a line makes the following text not grammatically correct. Of course, is possible to duplicate these variants of translations in * .ts files, but this will greatly increase it. This simple and short script allows you to avoid this. At a minimum, this script removes the second capital letters. Perhaps this is a temporary solution and in the future something better will be invented. Now this is worked only for the Russian language and this will not affect to other languages ​​in any way. However, if desired, other developers or translators can add their code to this script for own language.
