### PR TITLE
GUI translations

### DIFF
--- a/CountersunkHoles.py
+++ b/CountersunkHoles.py
@@ -243,7 +243,7 @@ class Ui_DlgCountersunktHoles(object):
 
     def fillScrewType(self, screwList):
         self.comboScrewType.clear()
-        self.comboScrewType.addItem("Default")
+        self.comboScrewType.addItem(translate("Fasteners", "Default"))
         for screw in screwList:
             self.comboScrewType.addItem(
                 QtGui.QIcon(os.path.join(iconPath, screw + ".svg")), screw

--- a/InitGui.py
+++ b/InitGui.py
@@ -100,7 +100,7 @@ class FastenersWorkbench(FreeCADGui.Workbench):
         "This is executed whenever the user right-clicks on screen"
         # "recipient" will be either "view" or "tree"
         self.appendContextMenu(
-            "Fasteners", self.list
+            translate("InitGui", "Fasteners"), self.list
         )  # add commands to the context menu
 
     def GetClassName(self):


### PR DESCRIPTION
I complete the GUI translations that are missing.

1.  3D view contextual menu 

    ![obraz](https://github.com/shaise/FreeCAD_FastenersWB/assets/39754351/0a879e63-45f0-4aa1-a4c0-f9d5a7006d53)

    `Fasteners` - no translation

2.  dialog of the FSFillet tool
    
    ![obraz](https://github.com/shaise/FreeCAD_FastenersWB/assets/39754351/f8ba3b71-38ab-4905-ba4c-bef59411edbd)

    `Default` - no translation

The context of the `translate()` function has been adjusted so that the translators have no extra work.