### PR TITLE
TranslateUtils.py: import translate from correct Draft file

### DIFF
--- a/TranslateUtils.py
+++ b/TranslateUtils.py
@@ -33,7 +33,7 @@ FreeCADGui.updateLocale()
 
 if FreeCAD.GuiUp:
     from PySide.QtCore import QT_TRANSLATE_NOOP
-    from DraftGui import translate
+    from draftutils.translate import translate
 else:
     def QT_TRANSLATE_NOOP(context, text):
         return text


### PR DESCRIPTION
Using
`from DraftGui import translate`
has the side-effect that the draftToolBar is initialized. In the Draft working plane code I am currently working on, I check for the presence of this toolbar to trigger the grid.

It is any case better to import directly:
`from draftutils.translate import translate`