### PR TITLE
Issue #297 FastenersCmd.FSViewProviderTree not JSON serializable patch

### DIFF
--- a/CountersunkHoles.py
+++ b/CountersunkHoles.py
@@ -622,16 +622,27 @@ class FSViewProviderCountersunk:
     def onChanged(self, vp, prop):
         return
 
-    def dumps(self):
-        #        return {'ObjectName' : self.Object.Name}
-        return None
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            #        return {'ObjectName' : self.Object.Name}
+            return None
 
-    def loads(self, state):
-        if state is not None:
-            import FreeCAD
+        def loads(self, state):
+            if state is not None:
+                import FreeCAD
+                doc = FreeCAD.ActiveDocument  # crap
+                self.Object = doc.getObject(state["ObjectName"])
 
-            doc = FreeCAD.ActiveDocument  # crap
-            self.Object = doc.getObject(state["ObjectName"])
+    else:
+        def __getstate__(self):
+            #        return {'ObjectName' : self.Object.Name}
+            return None
+
+        def __setstate__(self, state):
+            if state is not None:
+                import FreeCAD
+                doc = FreeCAD.ActiveDocument  # crap
+                self.Object = doc.getObject(state["ObjectName"])
 
     def claimChildren(self):
         objs = []

--- a/CountersunkHoles.py
+++ b/CountersunkHoles.py
@@ -622,11 +622,11 @@ class FSViewProviderCountersunk:
     def onChanged(self, vp, prop):
         return
 
-    def __getstate__(self):
+    def dumps(self):
         #        return {'ObjectName' : self.Object.Name}
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         if state is not None:
             import FreeCAD
 

--- a/FastenerBase.py
+++ b/FastenerBase.py
@@ -481,18 +481,27 @@ class FSViewProviderIcon:
         #        return {'ObjectName' : self.Object.Name}
         return None
 
-    def loads(self, state):
-        if state is not None:
-            import FreeCAD
-            doc = FreeCAD.ActiveDocument  # crap
-            self.Object = doc.getObject(state['ObjectName'])
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def loads(self, state):
+            if state is not None:
+                import FreeCAD
+                doc = FreeCAD.ActiveDocument  # crap
+                self.Object = doc.getObject(state['ObjectName'])
 
-    def getIcon(self):
-        for type in FSClassIcons:
-            if isinstance(self.Object.Proxy, type):
-                return os.path.join(iconPath, FSClassIcons[type])
-        return None
+        def dumps(self):
+            #        return {'ObjectName' : self.Object.Name}
+            return None
 
+    else:
+        def __setstate__(self, state):
+            if state is not None:
+                import FreeCAD
+                doc = FreeCAD.ActiveDocument  # crap
+                self.Object = doc.getObject(state['ObjectName'])
+
+        def __getstate__(self):
+            #        return {'ObjectName' : self.Object.Name}
+            return None
 
 def GetEdgeName(obj, edge):
     i = 1

--- a/FastenerBase.py
+++ b/FastenerBase.py
@@ -477,11 +477,11 @@ class FSViewProviderIcon:
     def onChanged(self, vp, prop):
         return
 
-    def __getstate__(self):
+    def dumps(self):
         #        return {'ObjectName' : self.Object.Name}
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         if state is not None:
             import FreeCAD
             doc = FreeCAD.ActiveDocument  # crap

--- a/FastenersCmd.py
+++ b/FastenersCmd.py
@@ -622,24 +622,35 @@ class FSViewProviderTree:
     def onChanged(self, vp, prop):
         return
 
-    def dumps(self):
-        #        return {'ObjectName' : self.Object.Name}
-        return None
+    if (FreeCAD.Version()[0]+'.'+FreeCAD.Version()[1]) >= '0.22':
+        def dumps(self):
+            #        return {'ObjectName' : self.Object.Name}
+            return None
 
-    def loads(self, state):
-        if state is not None:
-            import FreeCAD
-            doc = FreeCAD.ActiveDocument  # crap
-            self.Object = doc.getObject(state['ObjectName'])
+        def loads(self, state):
+            if state is not None:
+                import FreeCAD
+                doc = FreeCAD.ActiveDocument  # crap
+                self.Object = doc.getObject(state['ObjectName'])
+
+    else:
+        def __getstate__(self):
+            #        return {'ObjectName' : self.Object.Name}
+            return None
+
+        def __setstate__(self, state):
+            if state is not None:
+                import FreeCAD
+                doc = FreeCAD.ActiveDocument  # crap
+                self.Object = doc.getObject(state['ObjectName'])
 
     def getIcon(self):
         if hasattr(self.Object, "type"):
             return os.path.join(iconPath, self.Object.type + '.svg')
         elif hasattr(self.Object.Proxy, "type"):
-            return os.path.join(iconPath, self.Object.Proxy.type + '.svg')
+                return os.path.join(iconPath, self.Object.Proxy.type + '.svg')
         # default to ISO4017.svg
         return os.path.join(iconPath, 'ISO4017.svg')
-
 
 class FSScrewCommand:
     """Add Screw command"""

--- a/FastenersCmd.py
+++ b/FastenersCmd.py
@@ -622,11 +622,11 @@ class FSViewProviderTree:
     def onChanged(self, vp, prop):
         return
 
-    def __getstate__(self):
+    def dumps(self):
         #        return {'ObjectName' : self.Object.Name}
         return None
 
-    def __setstate__(self, state):
+    def loads(self, state):
         if state is not None:
             import FreeCAD
             doc = FreeCAD.ActiveDocument  # crap


### PR DESCRIPTION
Hi @shaise,  

Since Py3.11 the methods names __setstate__ and __getstate__ conflict with the method names added to the object class.

In [FreeCAD App: Fixe #10460](https://github.com/FreeCAD/FreeCAD/commit/83d4080fe8) they have been renamed to 'loads' and 'dumps' 
This functions are called by the FreeCAD file [src/App/PropertyPythonObject.cpp](https://github.com/FreeCAD/FreeCAD/blob/main/src/App/PropertyPythonObject.cpp)

@++;
Gauthier.
