### PR TITLE
Make license match SPDX ID

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
   <version>0.5.02</version>
   <date>2024-02-07</date>
   <maintainer email="shaise@gmail.com">Shai Seger</maintainer>
-  <license file="LICENSE">GPLv2</license>
+  <license file="LICENSE">GPL-2.0-or-later</license>
   <url type="repository" branch="master">https://github.com/shaise/FreeCAD_FastenersWB</url>
   <url type="readme">https://github.com/shaise/FreeCAD_FastenersWB/blob/master/README.md</url>
   <icon>Resources/Icons/FNLogo.svg</icon>


### PR DESCRIPTION
See https://spdx.org/licenses/ -- note that you might actually mean `GPL-2.0-only`, in which case use that instead (or `LGPL-2.1-or-later`, if you are relicensing, I guess).
