### PR TITLE
Fix commands' names

### DIFF
--- a/FSChangeParams.py
+++ b/FSChangeParams.py
@@ -439,6 +439,5 @@ class FSChangeParamCommand:
         return True
 
 
-# Fasteners_ChangeParameters
-Gui.addCommand("Fasteners_ChangeParams", FSChangeParamCommand())
-FSCommands.append("Fasteners_ChangeParams", "command")
+Gui.addCommand("Fasteners_ChangeParameters", FSChangeParamCommand())
+FSCommands.append("Fasteners_ChangeParameters", "command")

--- a/FSScrewCalc.py
+++ b/FSScrewCalc.py
@@ -222,6 +222,5 @@ class FSScrewCalcCommand:
         return True
 
 
-# Fasteners_ScrewCalculator
-Gui.addCommand("Fasteners_ScrewCalc", FSScrewCalcCommand())
-FastenerBase.FSCommands.append("Fasteners_ScrewCalc", "command")
+Gui.addCommand("Fasteners_ScrewCalculator", FSScrewCalcCommand())
+FastenerBase.FSCommands.append("Fasteners_ScrewCalculator", "command")

--- a/FastenerBase.py
+++ b/FastenerBase.py
@@ -808,9 +808,8 @@ class FSMakeSimpleCommand:
         return False
 
 
-# Fasteners_Shape
-Gui.addCommand("Fasteners_Simple", FSMakeSimpleCommand())
-FSCommands.append("Fasteners_Simple", "command")
+Gui.addCommand("Fasteners_Simplify", FSMakeSimpleCommand())
+FSCommands.append("Fasteners_Simplify", "command")
 
 ######################## MatchTypeInner/Outer commands ########################
 
@@ -984,6 +983,5 @@ class FSMakeBomCommand:
         return Gui.ActiveDocument is not None
 
 
-# Fasteners_BOM
-Gui.addCommand("Fasteners_MakeBOM", FSMakeBomCommand())
-FSCommands.append("Fasteners_MakeBOM", "command")
+Gui.addCommand("Fasteners_BOM", FSMakeBomCommand())
+FSCommands.append("Fasteners_BOM", "command")


### PR DESCRIPTION
Needed to make link to FreeCAD Wiki works fine.

I asked Roy to update "Simplify" Wiki page: https://forum.freecad.org/viewtopic.php?t=85208

Related #33 #353