### PR TITLE
Change MenuText of fasteners according to grouping mode

### DIFF
--- a/FastenersCmd.py
+++ b/FastenersCmd.py
@@ -865,10 +865,18 @@ class FSScrewCommand:
         import GrammaticalTools
 
         icon = os.path.join(iconPath, FSGetIconAlias(self.Type) + '.svg')
+
+        if FSParam.GetInt("ScrewToolbarGroupMode", 1) == 2:
+            menu_text = translate("FastenerCmd", "Add ") + GrammaticalTools.ToDativeCase(self.Help)
+            tooltip_text = "FS" + self.Type
+        else:
+            menu_text = translate("FastenerCmd", "Add ") + self.Type
+            tooltip_text = self.Help
+
         return {'Pixmap': icon,
                 # the name of a svg file available in the resources
-                'MenuText': translate("FastenerCmd", "Add ") + GrammaticalTools.ToDativeCase(self.Help),
-                'ToolTip': self.Help}
+                'MenuText': menu_text,
+                'ToolTip': tooltip_text}
 
     def Activated(self):
         for selObj in FastenerBase.FSGetAttachableSelections():
@@ -882,7 +890,7 @@ class FSScrewCommand:
                 a.ViewObject.LineWidth = FSParam.GetFloat("DefaultLineWidth", 1.0)
             if FSParam.GetBool("DefaultVertexSizeActive", False):
                 a.ViewObject.PointSize  = FSParam.GetFloat("DefaultVertexSize", 1.0)
-            
+
             FSViewProviderTree(a.ViewObject)
         FreeCAD.ActiveDocument.recompute()
         return


### PR DESCRIPTION
When the icons are not grouped in drop-down list the tooltip that appears is bloated/redundant, this changes expect to have cleaner tooltips.

![image](https://github.com/shaise/FreeCAD_FastenersWB/assets/53124818/99799f2c-7263-49d8-9368-945cbc718805)

Fix #355