### PR TITLE
Discard unneeded int casts in getStandardButtons methods

### DIFF
--- a/CountersunkHoles.py
+++ b/CountersunkHoles.py
@@ -559,7 +559,7 @@ class FSTaskFilletDialog:
         Gui.Selection.removeObserver(self.selobserver)
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Ok) + int(QtGui.QDialogButtonBox.Cancel)
+        return QtGui.QDialogButtonBox.Ok + QtGui.QDialogButtonBox.Cancel
 
     def addSelectionEdge(self, objname, edge):
         if objname == self.baseObj.Name:

--- a/FSChangeParams.py
+++ b/FSChangeParams.py
@@ -400,7 +400,7 @@ class FSTaskChangeParamDialog:
         return
 
     def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Ok) + int(QtGui.QDialogButtonBox.Cancel)
+        return QtGui.QDialogButtonBox.Ok + QtGui.QDialogButtonBox.Cancel
 
 
 class FSChangeParamCommand:


### PR DESCRIPTION
Because `QtWidgets.QDialogButtonBox.StandardButtons` are already converted into `int`s in FreeCAD's `Gui::TaskDialogPython::getStandardButtons`, such conversions in workbench code aren't needed. Also this fixes compatibility with PySide6.

https://github.com/FreeCAD/FreeCAD/blob/b9bfa5c5507506e4515816414cd27f4851d00489/src/Gui/TaskView/TaskDialogPython.cpp#L736-L754
