### PR TITLE
Fix bug when generating BOM

### DIFF
--- a/FastenerBase.py
+++ b/FastenerBase.py
@@ -179,8 +179,8 @@ def FSAddItemsToType(typeName, item):
 def FSScrewStr(obj):
     """Return the textual representation of the screw diameter x length
     + optional handedness ([M]<dia>x<len>[LH]), also accounting for
-    dia = obj.diameter if obj.diameter != 'Custom' else obj.diameterCustom
     custom size properties"""
+    dia = obj.diameter if obj.diameter != 'Custom' else obj.diameterCustom
     if isinstance(dia, FreeCAD.Units.Quantity):
         dia = str(float(dia.Value)).rstrip('0').rstrip('.')
     length = obj.length if obj.length != 'Custom' else obj.lengthCustom


### PR DESCRIPTION
Fixes this error, reported on forum https://forum.freecad.org/viewtopic.php?t=87169:

```
Running the Python command 'Fasteners_BOM' failed: Traceback (most recent call last):
  File "/home/john/.local/share/FreeCAD/Mod/fasteners/./FastenerBase.py", line 897, in Activated
    method(obj, cnt)
  File "/home/john/.local/share/FreeCAD/Mod/fasteners/./FastenerBase.py", line 915, in AddScrew
    " Screw ") + FSScrewStr(obj)
  File "/home/john/.local/share/FreeCAD/Mod/fasteners/./FastenerBase.py", line 184, in FSScrewStr
    if isinstance(dia, FreeCAD.Units.Quantity):

local variable 'dia' referenced before assignment
```