### PR TITLE
add slot width to autogenerated names for T-slot-nuts

### DIFF
--- a/FastenersCmd.py
+++ b/FastenersCmd.py
@@ -788,6 +788,8 @@ class FSScrewObject(FSBaseObject):
         if hasattr(fp, 'leftHanded'):
             if self.leftHanded:
                 label += 'LH'
+        if hasattr(fp, 'slotWidth'):
+            label += ' x ' + fp.slotWidth
         # Add translated name of fastener type
         selfFamilyType = translate("FastenerCmdTreeView", self.familyType)
         label += '-' + selfFamilyType


### PR DESCRIPTION
adds the slot width to the autogenerated names for T-slot-nuts:

Left: Old
Right: New
![Screenshot_20240501_113229](https://github.com/shaise/FreeCAD_FastenersWB/assets/13178920/3d2f0a26-f4da-43f9-8878-8243320c1639)
