### PR TITLE
Fix handling of edges from Links

### DIFF
--- a/FastenerBase.py
+++ b/FastenerBase.py
@@ -567,19 +567,19 @@ def PositionDone(center, radius, done_list, tol=1e-6):
     return False
 
 
-def FSGetAttachableSelections():
+def FSGetAttachableSelections(screwObj=None):
     asels = []
-    for selObj in Gui.Selection.getSelectionEx():
+    for selObj in Gui.Selection.getSelectionEx("", 0):
+        if screwObj is not None and selObj.Object == screwObj:
+            continue
+
         baseObjectNames = selObj.SubElementNames
         obj = selObj.Object
-        grp = obj.getParentGeoFeatureGroup()
-        if grp is not None and hasattr(grp, "TypeId") and grp.TypeId == "PartDesign::Body":
-            obj = grp
         position_done_list = []  # list with sublists to store the center and radius
         # of processed edges to avoid duplicate fasteners
 
         for baseObjectName in baseObjectNames:
-            shape = obj.Shape.getElement(baseObjectName)
+            shape = obj.getSubObject(baseObjectName)
 
             # add explicitly selected edges
             if hasattr(shape, "Curve"):
@@ -767,7 +767,7 @@ class FSMoveCommand:
             obj = selObj.Object
             if hasattr(obj, 'Proxy') and isinstance(obj.Proxy, FSBaseObject):
                 screwObj = obj
-        aselects = FSGetAttachableSelections()
+        aselects = FSGetAttachableSelections(screwObj)
         if len(aselects) > 0:
             edgeObj = aselects[0]
         return screwObj, edgeObj

--- a/FastenersCmd.py
+++ b/FastenersCmd.py
@@ -631,7 +631,7 @@ class FSScrewObject(FSBaseObject):
 
         try:
             baseobj = fp.baseObject[0]
-            shape = baseobj.Shape.getElement(fp.baseObject[1][0])
+            shape = baseobj.getSubObject(fp.baseObject[1][0])
         except:
             baseobj = None
             shape = None
@@ -811,7 +811,7 @@ class FSViewProviderTree:
     def __init__(self, obj):
         obj.Proxy = self
         self.Object = obj.Object
- 
+
     def attach(self, obj):
         self.Object = obj.Object
         return
@@ -884,7 +884,7 @@ class FSScrewCommand:
                 a.ViewObject.LineWidth = FSParam.GetFloat("DefaultLineWidth", 1.0)
             if FSParam.GetBool("DefaultVertexSizeActive", False):
                 a.ViewObject.PointSize  = FSParam.GetFloat("DefaultVertexSize", 1.0)
-            
+
             FSViewProviderTree(a.ViewObject)
         FreeCAD.ActiveDocument.recompute()
         return


### PR DESCRIPTION
Currently edges from Links and Link arrays are not handled properly.

Original issue:
https://github.com/FreeCAD/FreeCAD/issues/14068

Test file (remove the .zip extension):
[Fasteners_arrays_issue.FCStd.zip](https://github.com/shaise/FreeCAD_FastenersWB/files/15394806/Fasteners_arrays_issue.FCStd.zip)

The file contains a Link array, a Link to that array, a Body and a Link to that Body.

Additionally: Currently Fasteners_Move will fail if instead of the whole fastener a circular edge of the fastener is selected. This has been solved by adding the `screwObj` argument to `FSGetAttachableSelections`.




