### PR TITLE
Include missing strings to translation

### DIFF
--- a/FSChangeParams.py
+++ b/FSChangeParams.py
@@ -409,11 +409,11 @@ class FSChangeParamCommand:
     """Make holes for countersunk screws"""
 
     def GetResources(self):
-        icon = os.path.join(iconPath, 'IconChangeParam.svg')
+        icon = os.path.join(iconPath, "IconChangeParam.svg")
         return {
-            'Pixmap': icon,  # the name of a svg file available in the resources
-            'MenuText': _translate("DlgChangeParams", "Change fastener parameters", None),
-            'ToolTip': _translate("DlgChangeParams", "Change parameters of selected fasteners", None)
+            "Pixmap": icon,  # the name of a svg file available in the resources
+            "MenuText": translate("DlgChangeParams", "Change fastener parameters"),
+            "ToolTip": translate("DlgChangeParams", "Change parameters of selected fasteners"),
         }
 
     def Activated(self):

--- a/FSScrewCalc.py
+++ b/FSScrewCalc.py
@@ -45,8 +45,10 @@ translate = FreeCAD.Qt.translate
 try:
     _fromUtf8 = QtCore.QString.fromUtf8
 except AttributeError:
+
     def _fromUtf8(s):
         return s
+
 
 try:
     _encoding = QtGui.QApplication.UnicodeUTF8
@@ -54,6 +56,7 @@ try:
     def _translate(context, text, disambig):
         return QtGui.QApplication.translate(context, text, disambig, _encoding)
 except AttributeError:
+
     def _translate(context, text, disambig):
         return QtGui.QApplication.translate(context, text, disambig)
 
@@ -75,7 +78,8 @@ class Ui_DockWidget(object):
         self.label.setObjectName(_fromUtf8("label"))
         self.horizontalLayout.addWidget(self.label)
         spacerItem = QtGui.QSpacerItem(
-            40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
+            40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum
+        )
         self.horizontalLayout.addItem(spacerItem)
         self.comboFastenerType = QtGui.QComboBox(self.dockWidgetContents)
         self.comboFastenerType.setObjectName(_fromUtf8("comboFastenerType"))
@@ -87,7 +91,8 @@ class Ui_DockWidget(object):
         self.label_2.setObjectName(_fromUtf8("label_2"))
         self.horizontalLayout_2.addWidget(self.label_2)
         spacerItem1 = QtGui.QSpacerItem(
-            40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
+            40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum
+        )
         self.horizontalLayout_2.addItem(spacerItem1)
         self.comboDiameter = QtGui.QComboBox(self.dockWidgetContents)
         self.comboDiameter.setObjectName(_fromUtf8("comboDiameter"))
@@ -99,7 +104,8 @@ class Ui_DockWidget(object):
         self.labelHoleSize.setObjectName(_fromUtf8("labelHoleSize"))
         self.horizontalLayout_3.addWidget(self.labelHoleSize)
         spacerItem2 = QtGui.QSpacerItem(
-            40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
+            40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum
+        )
         self.horizontalLayout_3.addItem(spacerItem2)
         self.textHole = QtGui.QLineEdit(self.dockWidgetContents)
         self.textHole.setReadOnly(True)
@@ -107,7 +113,8 @@ class Ui_DockWidget(object):
         self.horizontalLayout_3.addWidget(self.textHole)
         self.verticalLayout.addLayout(self.horizontalLayout_3)
         spacerItem3 = QtGui.QSpacerItem(
-            20, 40, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
+            20, 40, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding
+        )
         self.verticalLayout.addItem(spacerItem3)
         self.gridLayout.addLayout(self.verticalLayout, 1, 0, 1, 1)
         DockWidget.setWidget(self.dockWidgetContents)
@@ -116,12 +123,10 @@ class Ui_DockWidget(object):
         QtCore.QMetaObject.connectSlotsByName(DockWidget)
 
     def retranslateUi(self, DockWidget):
-        DockWidget.setWindowTitle(_translate(
-            "DockWidget", "Screw hole calculator", None))
+        DockWidget.setWindowTitle(_translate("DockWidget", "Screw hole calculator", None))
         self.label.setText(_translate("DockWidget", "Fastener type:", None))
         self.label_2.setText(_translate("DockWidget", "Screw Diameter:", None))
-        self.labelHoleSize.setText(_translate(
-            "DockWidget", "Suggested Hole diameter (mm):", None))
+        self.labelHoleSize.setText(_translate("DockWidget", "Suggested Hole diameter (mm):", None))
 
         #######################################################################
         # End position for generated code from pyuic4
@@ -133,8 +138,7 @@ class Ui_DockWidget(object):
         self.comboFastenerType.clear()
         for type in FSCScrewTypes:
             icon, name, table = type
-            self.comboFastenerType.addItem(
-                QtGui.QIcon(os.path.join(iconPath, icon)), name)
+            self.comboFastenerType.addItem(QtGui.QIcon(os.path.join(iconPath, icon)), name)
 
     def fillDiameters(self):
         self.comboDiameter.clear()
@@ -162,7 +166,7 @@ FSCPEMPressNutHoleChart = (
     ("M6", 8.75),
     ("M8", 10.5),
     ("M10", 14),
-    ("M12", 17)
+    ("M12", 17),
 )
 
 # hole size +0.08
@@ -171,7 +175,7 @@ FSCPEMStandOffHoleChart = (
     ("3.5M3", 5.41),
     ("M3.5", 5.41),
     ("M4", 7.14),
-    ("M5", 7.14)
+    ("M5", 7.14),
 )
 
 FSCPEMStudHoleChart = (
@@ -181,15 +185,19 @@ FSCPEMStudHoleChart = (
     ("M4", 4),
     ("M5", 5),
     ("M6", 6),
-    ("M8", 8)
+    ("M8", 8),
 )
 
 FSCScrewTypes = (
-    ("ISO7045.svg", "Metric Screw", ScrewMaker.FSCScrewHoleChart),
-    ("PEMPressNut.svg", "PEM Press-nut", FSCPEMPressNutHoleChart),
-    ("PEMBLStandoff.svg", "PEM Stand-off", FSCPEMStandOffHoleChart),
-    ("PEMStud.svg", "PEM Stud", FSCPEMStudHoleChart),
-    ("ASMEB18.2.1.6.svg", "Inch Screw", ScrewMaker.FSC_Inch_ScrewHoleChart)
+    ("ISO7045.svg", translate("DockWidget", "Metric Screw"), ScrewMaker.FSCScrewHoleChart),
+    ("PEMPressNut.svg", translate("DockWidget", "PEM Press-nut"), FSCPEMPressNutHoleChart),
+    ("PEMBLStandoff.svg", translate("DockWidget", "PEM Stand-off"), FSCPEMStandOffHoleChart),
+    ("PEMStud.svg", translate("DockWidget", "PEM Stud"), FSCPEMStudHoleChart),
+    (
+        "ASMEB18.2.1.6.svg",
+        translate("DockWidget", "Inch Screw"),
+        ScrewMaker.FSC_Inch_ScrewHoleChart,
+    ),
 )
 
 FSScrewCalcDlg = QtGui.QDockWidget()
@@ -206,11 +214,11 @@ class FSScrewCalcCommand:
 
     def GetResources(self):
         FreeCAD.Console.PrintLog("Getting resources\n")
-        icon = os.path.join(iconPath, 'IconScrewCalc.svg')
+        icon = os.path.join(iconPath, "IconScrewCalc.svg")
         return {
-            'Pixmap': icon,  # the name of a svg file available in the resources
-            'MenuText': _translate("DockWidget", "Screw calculator", None),
-            'ToolTip': _translate("DockWidget", "Show a screw hole calculator", None)
+            "Pixmap": icon,  # the name of a svg file available in the resources
+            "MenuText": translate("DockWidget", "Screw calculator"),
+            "ToolTip": translate("DockWidget", "Show a screw hole calculator"),
         }
 
     def Activated(self):

--- a/Resources/translations/fasteners.ts
+++ b/Resources/translations/fasteners.ts
@@ -4,7 +4,7 @@
 <context>
     <name>CountersunkDeprecation</name>
     <message>
-        <location filename="../CountersunkHoles.py" line="767"/>
+        <location filename="../../CountersunkHoles.py" line="767"/>
         <source>The Fasteners Workbench countersunk holes feature is deprecated, and may be removed in the future. Please consider using a PartDesign Hole feature instead</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12,37 +12,43 @@
 <context>
     <name>DlgChangeParams</name>
     <message>
-        <location filename="../DlgChangeParams.ui" line="14"/>
+        <location filename="../../FSChangeParams.py" line="421"/>
+        <location filename="../../DlgChangeParams.ui" line="14"/>
         <source>Change fastener parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DlgChangeParams.ui" line="20"/>
+        <location filename="../../FSChangeParams.py" line="422"/>
+        <source>Change parameters of selected fasteners</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgChangeParams.ui" line="20"/>
         <source>Fastener Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DlgChangeParams.ui" line="28"/>
+        <location filename="../../DlgChangeParams.ui" line="28"/>
         <source>Fastener type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DlgChangeParams.ui" line="42"/>
+        <location filename="../../DlgChangeParams.ui" line="42"/>
         <source>Auto set diameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DlgChangeParams.ui" line="56"/>
+        <location filename="../../DlgChangeParams.ui" line="56"/>
         <source>Diameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DlgChangeParams.ui" line="70"/>
+        <location filename="../../DlgChangeParams.ui" line="70"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DlgChangeParams.ui" line="84"/>
+        <location filename="../../DlgChangeParams.ui" line="84"/>
         <source>Set length (mm):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -50,95 +56,130 @@
 <context>
     <name>DlgCountersunktHoles</name>
     <message>
-        <location filename="../DlgCountersunkHoles.ui" line="14"/>
-        <source>Countersunk screw holes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../DlgCountersunkHoles.ui" line="20"/>
-        <source>Shape</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../DlgCountersunkHoles.ui" line="32"/>
-        <source>Base shape:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../DlgCountersunkHoles.ui" line="39"/>
-        <source>Base</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../DlgCountersunkHoles.ui" line="49"/>
-        <source>Chamfer Parameters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../DlgCountersunkHoles.ui" line="73"/>
-        <source>All</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../DlgCountersunkHoles.ui" line="80"/>
-        <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../DlgCountersunkHoles.ui" line="100"/>
-        <source>Diameter:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../DlgCountersunkHoles.ui" line="108"/>
-        <source>No selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../DlgCountersunkHoles.ui" line="139"/>
-        <source>Screw type:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../DlgCountersunkHoles.ui" line="147"/>
-        <source>No Selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../CountersunkHoles.py" line="189"/>
+        <location filename="../../CountersunkHoles.py" line="189"/>
         <source>Edges to chamfer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../CountersunkHoles.py" line="195"/>
+        <location filename="../../CountersunkHoles.py" line="195"/>
         <source>Diameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../CountersunkHoles.py" line="530"/>
+        <location filename="../../CountersunkHoles.py" line="530"/>
         <source>Chamfer holes for countersunk screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgCountersunkHoles.ui" line="14"/>
+        <source>Countersunk screw holes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgCountersunkHoles.ui" line="20"/>
+        <source>Shape</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgCountersunkHoles.ui" line="32"/>
+        <source>Base shape:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgCountersunkHoles.ui" line="39"/>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgCountersunkHoles.ui" line="49"/>
+        <source>Chamfer Parameters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgCountersunkHoles.ui" line="73"/>
+        <source>All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgCountersunkHoles.ui" line="80"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgCountersunkHoles.ui" line="100"/>
+        <source>Diameter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgCountersunkHoles.ui" line="108"/>
+        <source>No selection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgCountersunkHoles.ui" line="139"/>
+        <source>Screw type:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../DlgCountersunkHoles.ui" line="147"/>
+        <source>No Selection</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DockWidget</name>
     <message>
-        <location filename="../WidgetScrewCalc.ui" line="17"/>
+        <location filename="../../FSScrewCalc.py" line="192"/>
+        <source>Metric Screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FSScrewCalc.py" line="193"/>
+        <source>PEM Press-nut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FSScrewCalc.py" line="194"/>
+        <source>PEM Stand-off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FSScrewCalc.py" line="195"/>
+        <source>PEM Stud</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FSScrewCalc.py" line="198"/>
+        <source>Inch Screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FSScrewCalc.py" line="220"/>
+        <source>Screw calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FSScrewCalc.py" line="221"/>
+        <source>Show a screw hole calculator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../WidgetScrewCalc.ui" line="17"/>
         <source>Screw hole calculator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WidgetScrewCalc.ui" line="28"/>
+        <location filename="../../WidgetScrewCalc.ui" line="28"/>
         <source>Fastener type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WidgetScrewCalc.ui" line="55"/>
+        <location filename="../../WidgetScrewCalc.ui" line="55"/>
         <source>Screw Diameter:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WidgetScrewCalc.ui" line="82"/>
+        <location filename="../../WidgetScrewCalc.ui" line="82"/>
         <source>Suggested Hole diameter (mm):</source>
         <translation type="unfinished"></translation>
     </message>
@@ -146,152 +187,152 @@
 <context>
     <name>FastenerBase</name>
     <message>
-        <location filename="../FastenerBase.py" line="46"/>
+        <location filename="../../FastenerBase.py" line="46"/>
         <source>Match for pass hole</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="48"/>
+        <location filename="../../FastenerBase.py" line="48"/>
         <source>Match for tap hole</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="51"/>
+        <location filename="../../FastenerBase.py" line="51"/>
         <source>FS Commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="734"/>
+        <location filename="../../FastenerBase.py" line="737"/>
         <source>Invert fastener</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="738"/>
+        <location filename="../../FastenerBase.py" line="738"/>
         <source>Invert fastener orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="775"/>
+        <location filename="../../FastenerBase.py" line="779"/>
         <source>Move fastener</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="779"/>
+        <location filename="../../FastenerBase.py" line="780"/>
         <source>Move fastener to a new location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="818"/>
+        <location filename="../../FastenerBase.py" line="823"/>
         <source>Simplify shape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="822"/>
+        <location filename="../../FastenerBase.py" line="824"/>
         <source>Change object to simple non-parametric shape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="865"/>
+        <location filename="../../FastenerBase.py" line="869"/>
         <source>Match screws by inner thread diameter (Tap hole)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="883"/>
+        <location filename="../../FastenerBase.py" line="888"/>
         <source>Match screws by outer thread diameter (Pass hole)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="906"/>
+        <location filename="../../FastenerBase.py" line="921"/>
         <source>Generate BOM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="909"/>
+        <location filename="../../FastenerBase.py" line="922"/>
         <source>Generate fasteners bill of material</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="914"/>
+        <location filename="../../FastenerBase.py" line="929"/>
         <source>Fasteners_BOM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="915"/>
+        <location filename="../../FastenerBase.py" line="930"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="916"/>
+        <location filename="../../FastenerBase.py" line="931"/>
         <source>Qty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="941"/>
+        <location filename="../../FastenerBase.py" line="955"/>
         <source> Screw </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="950"/>
+        <location filename="../../FastenerBase.py" line="963"/>
         <source> Nut </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="954"/>
+        <location filename="../../FastenerBase.py" line="966"/>
         <source> Washer </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="957"/>
+        <location filename="../../FastenerBase.py" line="969"/>
         <source>Threaded Rod </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="962"/>
+        <location filename="../../FastenerBase.py" line="973"/>
         <source>PEM PressNut </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="966"/>
+        <location filename="../../FastenerBase.py" line="976"/>
         <source>PEM Standoff </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="970"/>
+        <location filename="../../FastenerBase.py" line="979"/>
         <source>PEM Stud </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="975"/>
+        <location filename="../../FastenerBase.py" line="983"/>
         <source>PCB Standoff </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="980"/>
+        <location filename="../../FastenerBase.py" line="987"/>
         <source>Heat Set Insert </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="984"/>
+        <location filename="../../FastenerBase.py" line="990"/>
         <source> Retaining Ring </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="989"/>
+        <location filename="../../FastenerBase.py" line="995"/>
         <source> T-Slot Bolt </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="992"/>
+        <location filename="../../FastenerBase.py" line="999"/>
         <source> T-Slot Nut </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="996"/>
+        <location filename="../../FastenerBase.py" line="1003"/>
         <source> Hex key </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="1000"/>
+        <location filename="../../FastenerBase.py" line="1006"/>
         <source> Nail </source>
         <translation type="unfinished"></translation>
     </message>
@@ -299,1211 +340,1211 @@
 <context>
     <name>FastenerCmd</name>
     <message>
-        <location filename="../FastenerBase.py" line="77"/>
+        <location filename="../../FastenerBase.py" line="79"/>
         <source>Offset from surface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="80"/>
+        <location filename="../../FastenerBase.py" line="85"/>
         <source>Attachment rotation offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="83"/>
+        <location filename="../../FastenerBase.py" line="90"/>
         <source>Invert fastener direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenerBase.py" line="86"/>
-        <location filename="../FastenerBase.py" line="93"/>
+        <location filename="../../FastenerBase.py" line="94"/>
+        <location filename="../../FastenerBase.py" line="102"/>
         <source>Base object</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="97"/>
+        <location filename="../../FastenersCmd.py" line="97"/>
         <source>Hex head</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="98"/>
+        <location filename="../../FastenersCmd.py" line="98"/>
         <source>Hexagon socket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="99"/>
+        <location filename="../../FastenersCmd.py" line="99"/>
         <source>Hexalobular socket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="100"/>
+        <location filename="../../FastenersCmd.py" line="100"/>
         <source>Slotted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="101"/>
+        <location filename="../../FastenersCmd.py" line="101"/>
         <source>H cross</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="102"/>
+        <location filename="../../FastenersCmd.py" line="102"/>
         <source>Nut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="103"/>
+        <location filename="../../FastenersCmd.py" line="103"/>
         <source>Washer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="104"/>
+        <location filename="../../FastenersCmd.py" line="104"/>
         <source>Misc head</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="105"/>
+        <location filename="../../FastenersCmd.py" line="105"/>
         <source>ThreadedRod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="106"/>
+        <location filename="../../FastenersCmd.py" line="106"/>
         <source>Inserts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="107"/>
+        <location filename="../../FastenersCmd.py" line="107"/>
         <source>Retaining Rings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="108"/>
+        <location filename="../../FastenersCmd.py" line="108"/>
         <source>T-Slot Fasteners</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="109"/>
+        <location filename="../../FastenersCmd.py" line="109"/>
         <source>Set screws</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="110"/>
+        <location filename="../../FastenersCmd.py" line="110"/>
         <source>Nails</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="111"/>
+        <location filename="../../FastenersCmd.py" line="111"/>
         <source>Pins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="113"/>
+        <location filename="../../FastenersCmd.py" line="113"/>
         <source>Thumb screws</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="124"/>
-        <source>UNC Hex head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="125"/>
-        <source>UNC Hex head screws with flange</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="126"/>
-        <source>Hex head wood screw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="127"/>
-        <location filename="../FastenersCmd.py" line="128"/>
-        <source>Hex head screw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="129"/>
-        <source>Hexagon bolt with flange, small series</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="130"/>
-        <source>Hexagon bolt with flange, heavy series</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="131"/>
-        <source>Hex head bolt - Product grades A and B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="132"/>
-        <source>Hexagon head bolts with reduced shank</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="133"/>
-        <source>Hex head bolts - Product grade C</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="134"/>
-        <source>Hex head screw - Product grades A and B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="135"/>
-        <source>Hex head screws - Product grade C</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="136"/>
-        <source>Hexagon bolts with flange - Small series - Product grade A with driving feature of product grade B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="137"/>
-        <source>Hex head screws with fine pitch thread</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="138"/>
-        <source>Hex head bolt with fine pitch thread</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="139"/>
-        <source>Hexagon bolts with flange - Small series - Product grade A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="140"/>
-        <source>Hexagon bolts with flange with fine pitch thread - Small series - Product grade A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="144"/>
-        <source>UNC Hex socket head cap screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="145"/>
-        <source>UNC Hex socket head cap screws with low head</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="146"/>
-        <source>UNC Hex socket countersunk head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="147"/>
-        <source>UNC Hex socket button head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="148"/>
-        <source>UNC Hex socket button head screws with flange</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="149"/>
-        <source>UNC Hexagon socket head shoulder screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="150"/>
-        <source>Hexagon socket head cap screws with low head with centre</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="151"/>
-        <source>Hexagon socket head cap screws with low head</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="152"/>
-        <source>Hexagon socket screw keys</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="153"/>
-        <source>Hexagon socket head cap screw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="154"/>
-        <source>Hexagon socket head shoulder screw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="155"/>
-        <source>Hexagon socket button head screw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="156"/>
-        <source>Hexagon socket button head screws with collar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="157"/>
-        <source>Hexagon socket countersunk head screw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="161"/>
-        <source>Hexalobular socket head cap screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="162"/>
-        <source>Hexalobular socket cheese head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="163"/>
-        <source>Hexalobular socket countersunk flat head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="164"/>
-        <source>Hexalobular socket countersunk head screws, high head</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="165"/>
-        <source>Hexalobular socket pan head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="166"/>
-        <source>Hexalobular socket raised countersunk head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="170"/>
-        <source>Slotted flat countersunk head wood screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="171"/>
-        <source>Slotted oval countersunk head wood screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="172"/>
-        <source>UNC slotted countersunk flat head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="173"/>
-        <source>UNC Slotted oval countersunk head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="174"/>
-        <source>UNC Slotted pan head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="175"/>
-        <source>UNC Slotted fillister head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="176"/>
-        <source>UNC Slotted truss head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="177"/>
-        <source>UNC Slotted round head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="179"/>
-        <source>Slotted half round head wood screw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="180"/>
-        <source>(Type 1) Half — round head wood screw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="181"/>
-        <source>(Type 2) Half — round head wood screw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="182"/>
-        <source>Slotted cheese head screw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="183"/>
-        <source>Slotted pan head screw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="184"/>
-        <source>Slotted countersunk flat head screw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="185"/>
-        <source>Slotted raised countersunk head screw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="189"/>
-        <source>Cross recessed flat countersunk head wood screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="190"/>
-        <source>Cross recessed oval countersunk head wood screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="191"/>
-        <source>UNC Cross recessed countersunk flat head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="192"/>
-        <source>UNC Cross recessed oval countersunk head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="193"/>
-        <source>UNC Cross recessed pan head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="194"/>
-        <source>UNC Cross recessed fillister head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="195"/>
-        <source>UNC Cross recessed truss head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="196"/>
-        <source>UNC Cross recessed round head screws</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="197"/>
-        <source>Cross recessed pan head screws with collar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="198"/>
-        <source>Cross recessed pan head wood screw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="199"/>
-        <source>(Type 3) Half — round head wood screw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="200"/>
-        <source>(Type 4) Half — round head wood screw</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="201"/>
-        <source>Pan head screws type H cross recess</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="202"/>
-        <source>Countersunk flat head screws H cross r.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="203"/>
-        <source>Raised countersunk head screws H cross r.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="204"/>
-        <source>Cheese head screws with type H cross r.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="205"/>
-        <source>Pan head self tapping screws with conical point, type H cross r.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="206"/>
-        <source>Pan head self tapping screws with flat point, type H cross r.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="207"/>
-        <source>Pan head self tapping screws with rounded point type H cross r.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="123"/>
-        <location filename="../FastenersCmd.py" line="211"/>
+        <location filename="../../FastenersCmd.py" line="123"/>
+        <location filename="../../FastenersCmd.py" line="211"/>
         <source>UNC Square bolts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="178"/>
+        <location filename="../../FastenersCmd.py" line="124"/>
+        <source>UNC Hex head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="125"/>
+        <source>UNC Hex head screws with flange</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="126"/>
+        <source>Hex head wood screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="127"/>
+        <location filename="../../FastenersCmd.py" line="128"/>
+        <source>Hex head screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="129"/>
+        <source>Hexagon bolt with flange, small series</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="130"/>
+        <source>Hexagon bolt with flange, heavy series</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="131"/>
+        <source>Hex head bolt - Product grades A and B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="132"/>
+        <source>Hexagon head bolts with reduced shank</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="133"/>
+        <source>Hex head bolts - Product grade C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="134"/>
+        <source>Hex head screw - Product grades A and B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="135"/>
+        <source>Hex head screws - Product grade C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="136"/>
+        <source>Hexagon bolts with flange - Small series - Product grade A with driving feature of product grade B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="137"/>
+        <source>Hex head screws with fine pitch thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="138"/>
+        <source>Hex head bolt with fine pitch thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="139"/>
+        <source>Hexagon bolts with flange - Small series - Product grade A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="140"/>
+        <source>Hexagon bolts with flange with fine pitch thread - Small series - Product grade A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="144"/>
+        <source>UNC Hex socket head cap screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="145"/>
+        <source>UNC Hex socket head cap screws with low head</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="146"/>
+        <source>UNC Hex socket countersunk head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="147"/>
+        <source>UNC Hex socket button head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="148"/>
+        <source>UNC Hex socket button head screws with flange</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="149"/>
+        <source>UNC Hexagon socket head shoulder screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="150"/>
+        <source>Hexagon socket head cap screws with low head with centre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="151"/>
+        <source>Hexagon socket head cap screws with low head</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="152"/>
+        <source>Hexagon socket screw keys</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="153"/>
+        <source>Hexagon socket head cap screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="154"/>
+        <source>Hexagon socket head shoulder screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="155"/>
+        <source>Hexagon socket button head screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="156"/>
+        <source>Hexagon socket button head screws with collar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="157"/>
+        <source>Hexagon socket countersunk head screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="161"/>
+        <source>Hexalobular socket head cap screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="162"/>
+        <source>Hexalobular socket cheese head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="163"/>
+        <source>Hexalobular socket countersunk flat head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="164"/>
+        <source>Hexalobular socket countersunk head screws, high head</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="165"/>
+        <source>Hexalobular socket pan head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="166"/>
+        <source>Hexalobular socket raised countersunk head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="170"/>
+        <source>Slotted flat countersunk head wood screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="171"/>
+        <source>Slotted oval countersunk head wood screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="172"/>
+        <source>UNC slotted countersunk flat head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="173"/>
+        <source>UNC Slotted oval countersunk head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="174"/>
+        <source>UNC Slotted pan head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="175"/>
+        <source>UNC Slotted fillister head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="176"/>
+        <source>UNC Slotted truss head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="177"/>
+        <source>UNC Slotted round head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="178"/>
         <source>(Superseded by ISO 1207) Slotted cheese head screw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="212"/>
+        <location filename="../../FastenersCmd.py" line="179"/>
+        <source>Slotted half round head wood screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="180"/>
+        <source>(Type 1) Half — round head wood screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="181"/>
+        <source>(Type 2) Half — round head wood screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="182"/>
+        <source>Slotted cheese head screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="183"/>
+        <source>Slotted pan head screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="184"/>
+        <source>Slotted countersunk flat head screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="185"/>
+        <source>Slotted raised countersunk head screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="189"/>
+        <source>Cross recessed flat countersunk head wood screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="190"/>
+        <source>Cross recessed oval countersunk head wood screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="191"/>
+        <source>UNC Cross recessed countersunk flat head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="192"/>
+        <source>UNC Cross recessed oval countersunk head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="193"/>
+        <source>UNC Cross recessed pan head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="194"/>
+        <source>UNC Cross recessed fillister head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="195"/>
+        <source>UNC Cross recessed truss head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="196"/>
+        <source>UNC Cross recessed round head screws</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="197"/>
+        <source>Cross recessed pan head screws with collar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="198"/>
+        <source>Cross recessed pan head wood screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="199"/>
+        <source>(Type 3) Half — round head wood screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="200"/>
+        <source>(Type 4) Half — round head wood screw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="201"/>
+        <source>Pan head screws type H cross recess</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="202"/>
+        <source>Countersunk flat head screws H cross r.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="203"/>
+        <source>Raised countersunk head screws H cross r.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="204"/>
+        <source>Cheese head screws with type H cross r.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="205"/>
+        <source>Pan head self tapping screws with conical point, type H cross r.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="206"/>
+        <source>Pan head self tapping screws with flat point, type H cross r.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="207"/>
+        <source>Pan head self tapping screws with rounded point type H cross r.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="212"/>
         <source>UNC Round head square neck bolts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="213"/>
+        <location filename="../../FastenersCmd.py" line="213"/>
         <source>Square head bolts with collar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="214"/>
+        <location filename="../../FastenersCmd.py" line="214"/>
         <source>Mushroom head square neck bolts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="215"/>
+        <location filename="../../FastenersCmd.py" line="215"/>
         <source>headless screws with shank</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="219"/>
+        <location filename="../../FastenersCmd.py" line="219"/>
         <source>UNC Hexagon socket set screws with flat point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="220"/>
+        <location filename="../../FastenersCmd.py" line="220"/>
         <source>UNC Hexagon socket set screws with cone point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="221"/>
+        <location filename="../../FastenersCmd.py" line="221"/>
         <source>UNC Hexagon socket set screws with dog point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="222"/>
+        <location filename="../../FastenersCmd.py" line="222"/>
         <source>UNC Hexagon socket set screws with cup point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="223"/>
+        <location filename="../../FastenersCmd.py" line="223"/>
         <source>Hexagon socket set screws with flat point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="224"/>
+        <location filename="../../FastenersCmd.py" line="224"/>
         <source>Hexagon socket set screws with cone point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="225"/>
+        <location filename="../../FastenersCmd.py" line="225"/>
         <source>Hexagon socket set screws with dog point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="226"/>
+        <location filename="../../FastenersCmd.py" line="226"/>
         <source>Hexagon socket set screws with cup point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="227"/>
+        <location filename="../../FastenersCmd.py" line="227"/>
         <source>Slotted socket set screws with flat point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="228"/>
+        <location filename="../../FastenersCmd.py" line="228"/>
         <source>Slotted socket set screws with cone point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="229"/>
+        <location filename="../../FastenersCmd.py" line="229"/>
         <source>Slotted socket set screws with long dog point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="230"/>
+        <location filename="../../FastenersCmd.py" line="230"/>
         <source>Slotted socket set screws with cup point</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="234"/>
+        <location filename="../../FastenersCmd.py" line="234"/>
         <source>Knurled thumb screws, high type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="235"/>
+        <location filename="../../FastenersCmd.py" line="235"/>
         <source>Slotted knurled thumb screws, high type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="236"/>
+        <location filename="../../FastenersCmd.py" line="236"/>
         <source>Knurled thumb screws, low type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="240"/>
+        <location filename="../../FastenersCmd.py" line="240"/>
         <source>UNC Hex Machine screw nuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="241"/>
+        <location filename="../../FastenersCmd.py" line="241"/>
         <source>UNC Square machine screw nuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="242"/>
+        <location filename="../../FastenersCmd.py" line="242"/>
         <source>UNC Square nuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="243"/>
+        <location filename="../../FastenersCmd.py" line="243"/>
         <source>UNC Hexagon nuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="244"/>
+        <location filename="../../FastenersCmd.py" line="244"/>
         <source>UNC Hexagon thin nuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="245"/>
+        <location filename="../../FastenersCmd.py" line="245"/>
         <source>UNC Hex slotted nuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="246"/>
+        <location filename="../../FastenersCmd.py" line="246"/>
         <source>UNC Hex flange nuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="247"/>
+        <location filename="../../FastenersCmd.py" line="247"/>
         <source>UNC Hex coupling nuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="250"/>
-        <location filename="../FastenersCmd.py" line="251"/>
-        <source>Square nuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="252"/>
-        <source>Cap nuts, thin style</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="256"/>
-        <source>Slotted / Castle nuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="257"/>
-        <source>Nyloc nuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="258"/>
-        <source>Cap nuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="259"/>
-        <source>Hexagon nuts with a height of 1,5 d</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="260"/>
-        <source>Hexagon nuts with collar height 1,5 d</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="264"/>
-        <source>(Type 1) Cap nuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="266"/>
-        <source>Hexagon nuts, Style 2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="265"/>
-        <location filename="../FastenersCmd.py" line="267"/>
-        <source>Hexagon nuts, Style 1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="268"/>
-        <source>Hexagon thin nuts, chamfered</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="263"/>
-        <location filename="../FastenersCmd.py" line="270"/>
-        <source>Hexagon nuts with flange</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="273"/>
-        <source>Prevailing torque type hexagon nuts with flange (with non-metallic insert)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="274"/>
-        <source>Prevailing torque type all-metal hexagon nuts with flange</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="275"/>
-        <source>Prevailing torque type all-metal hexagon regular nuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="276"/>
-        <source>Prevailing torque type all-metal hexagon nuts, style 2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="277"/>
-        <source>Hexagon regular nuts (style 1) with metric fine pitch thread — Product grades A and B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="278"/>
-        <source>Hexagon high nuts (style 2) with metric fine pitch thread </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="279"/>
-        <source>Hexagon thin nuts chamfered (style 0) with metric fine pitch thread — Product grades A and B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="282"/>
-        <source>Prevailing torque type all-metal hexagon nuts with fine pitch thread</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="283"/>
-        <source>Hexagon nuts with flange - fine pitch thread</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="284"/>
-        <source>Prevailing torque type hexagon nuts with flange (with non-metallic insert) - fine pitch thread</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="285"/>
-        <source>Prevailing torque type all-metal hexagon nuts with flange - fine pitch thread</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="286"/>
-        <source>Hexagon weld nuts with flange</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="293"/>
-        <source>GN 505 Serrated Quarter-Turn T-Slot nuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="294"/>
-        <source>GN 505.4 Serrated T-Slot Bolts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="295"/>
-        <source>GN 506 T-Slot nuts to swivel in</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="296"/>
-        <source>GN 507 T-Slot sliding nuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="292"/>
-        <location filename="../FastenersCmd.py" line="297"/>
-        <source>T-Slot nuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="248"/>
+        <location filename="../../FastenersCmd.py" line="248"/>
         <source>Wing nuts, type A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="249"/>
+        <location filename="../../FastenersCmd.py" line="249"/>
         <source>Wing nuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="253"/>
+        <location filename="../../FastenersCmd.py" line="250"/>
+        <location filename="../../FastenersCmd.py" line="251"/>
+        <source>Square nuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="252"/>
+        <source>Cap nuts, thin style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="253"/>
         <source>Square weld nuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="254"/>
+        <location filename="../../FastenersCmd.py" line="254"/>
         <source>Hexagonal weld nuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="255"/>
+        <location filename="../../FastenersCmd.py" line="255"/>
         <source>(Superseded by ISO 4035 and ISO 8673) Hexagon thin nuts, chamfered</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="261"/>
+        <location filename="../../FastenersCmd.py" line="256"/>
+        <source>Slotted / Castle nuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="257"/>
+        <source>Nyloc nuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="258"/>
+        <source>Cap nuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="259"/>
+        <source>Hexagon nuts with a height of 1,5 d</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="260"/>
+        <source>Hexagon nuts with collar height 1,5 d</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="261"/>
         <source>Elongated hexagon nuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="262"/>
+        <location filename="../../FastenersCmd.py" line="262"/>
         <source>Self locking counter nuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="271"/>
+        <location filename="../../FastenersCmd.py" line="263"/>
+        <location filename="../../FastenersCmd.py" line="270"/>
+        <source>Hexagon nuts with flange</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="264"/>
+        <source>(Type 1) Cap nuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="265"/>
+        <location filename="../../FastenersCmd.py" line="267"/>
+        <source>Hexagon nuts, Style 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="266"/>
+        <source>Hexagon nuts, Style 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="268"/>
+        <source>Hexagon thin nuts, chamfered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="271"/>
         <source>Prevailing torque type hexagon nuts (with non-metallic insert)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="272"/>
+        <location filename="../../FastenersCmd.py" line="272"/>
         <source>Prevailing torque type hexagon nuts (with non-metallic insert), style 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="280"/>
+        <location filename="../../FastenersCmd.py" line="273"/>
+        <source>Prevailing torque type hexagon nuts with flange (with non-metallic insert)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="274"/>
+        <source>Prevailing torque type all-metal hexagon nuts with flange</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="275"/>
+        <source>Prevailing torque type all-metal hexagon regular nuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="276"/>
+        <source>Prevailing torque type all-metal hexagon nuts, style 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="277"/>
+        <source>Hexagon regular nuts (style 1) with metric fine pitch thread — Product grades A and B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="278"/>
+        <source>Hexagon high nuts (style 2) with metric fine pitch thread </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="279"/>
+        <source>Hexagon thin nuts chamfered (style 0) with metric fine pitch thread — Product grades A and B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="280"/>
         <source>Prevailing torque type hexagon thin nuts (with non-metallic insert)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="281"/>
+        <location filename="../../FastenersCmd.py" line="281"/>
         <source>Prevailing torque type hexagon nuts (with non-metallic insert) - fine pitch thread</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="287"/>
+        <location filename="../../FastenersCmd.py" line="282"/>
+        <source>Prevailing torque type all-metal hexagon nuts with fine pitch thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="283"/>
+        <source>Hexagon nuts with flange - fine pitch thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="284"/>
+        <source>Prevailing torque type hexagon nuts with flange (with non-metallic insert) - fine pitch thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="285"/>
+        <source>Prevailing torque type all-metal hexagon nuts with flange - fine pitch thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="286"/>
+        <source>Hexagon weld nuts with flange</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="287"/>
         <source>Low cap nuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="288"/>
+        <location filename="../../FastenersCmd.py" line="288"/>
         <source>High cap nuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="301"/>
+        <location filename="../../FastenersCmd.py" line="292"/>
+        <location filename="../../FastenersCmd.py" line="297"/>
+        <source>T-Slot nuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="293"/>
+        <source>GN 505 Serrated Quarter-Turn T-Slot nuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="294"/>
+        <source>GN 505.4 Serrated T-Slot Bolts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="295"/>
+        <source>GN 506 T-Slot nuts to swivel in</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="296"/>
+        <source>GN 507 T-Slot sliding nuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="301"/>
         <source>UN washers, narrow series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="302"/>
+        <location filename="../../FastenersCmd.py" line="302"/>
         <source>UN washers, regular series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="303"/>
+        <location filename="../../FastenersCmd.py" line="303"/>
         <source>UN washers, wide series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="304"/>
+        <location filename="../../FastenersCmd.py" line="304"/>
         <source>Spherical washer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="305"/>
-        <location filename="../FastenersCmd.py" line="306"/>
+        <location filename="../../FastenersCmd.py" line="305"/>
+        <location filename="../../FastenersCmd.py" line="306"/>
         <source>Conical seat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="307"/>
+        <location filename="../../FastenersCmd.py" line="307"/>
         <source>Washers for clamping devices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="308"/>
+        <location filename="../../FastenersCmd.py" line="308"/>
         <source>Plain washers - Normal series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="309"/>
+        <location filename="../../FastenersCmd.py" line="309"/>
         <source>Plain Washers, chamfered - Normal series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="311"/>
+        <location filename="../../FastenersCmd.py" line="311"/>
         <source>Plain washers - Small series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="312"/>
+        <location filename="../../FastenersCmd.py" line="312"/>
         <source>Plain washers - Large series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="313"/>
+        <location filename="../../FastenersCmd.py" line="313"/>
         <source>Plain washers - Extra large series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="314"/>
+        <location filename="../../FastenersCmd.py" line="314"/>
         <source>Plain washers for clevis pins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="315"/>
+        <location filename="../../FastenersCmd.py" line="315"/>
         <source>NFE27-619 Countersunk washer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="319"/>
+        <location filename="../../FastenersCmd.py" line="319"/>
         <source>Inch threaded rod for tapping holes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="320"/>
+        <location filename="../../FastenersCmd.py" line="320"/>
         <source>Tool object to cut external non-metric threads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="321"/>
+        <location filename="../../FastenersCmd.py" line="321"/>
         <source>UNC threaded rod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="323"/>
-        <source>Metric threaded rod for tapping holes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="324"/>
-        <source>Tool object to cut external metric threads</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="328"/>
-        <source>IUT[A/B/C] Heat Staked Metric Insert</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="329"/>
-        <source>PEM Self Clinching nut</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="330"/>
-        <source>PEM Self Clinching standoff</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="331"/>
-        <source>PEM Self Clinching stud</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="332"/>
-        <source>Wurth WA-SSTII PCB spacer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="333"/>
-        <source>Wurth WA-SSTII  PCB standoff</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="334"/>
-        <source>4 Prong Wood Thread Insert (DIN 1624 Tee nuts)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="338"/>
-        <source>Metric external retaining rings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="339"/>
-        <source>Metric internal retaining rings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="340"/>
-        <source>Metric E-clip retaining rings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="344"/>
-        <source>Round plain head nails for use in automatic nailing machines</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="345"/>
-        <source>Nails for the installation of wood wool composite panels, 20mm round head</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="346"/>
-        <source>Round plain head wire nails</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="347"/>
-        <source>Round countersunk head wire nails</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="348"/>
-        <source>Round lost head wire nails</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="349"/>
-        <source>Clout or slate nails</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="350"/>
-        <source>Clout or slate wide head nails</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="353"/>
-        <source>Split pins</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="354"/>
-        <source>Parallel pins</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="355"/>
-        <source>Taper pins</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="356"/>
-        <source>Clevis pins without head</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="357"/>
-        <source>Clevis pins without head (with split pin holes)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="358"/>
-        <source>Clevis pins with head</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="359"/>
-        <source>Clevis pins with head (with split pin hole)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="360"/>
-        <source>Parallel pins with internal thread, unhardened</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="361"/>
-        <source>Dowel pins</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="362"/>
-        <source>Parallel pins with internal thread, hardened</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="363"/>
-        <source>Taper pins with internal thread, unhardened</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="364"/>
-        <source>Taper pins with external thread, unhardened</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="365"/>
-        <source>Full-length grooved pins with pilot</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="366"/>
-        <source>Full-length grooved pins with chamfer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="367"/>
-        <source>Half-length reverse taper grooved pins</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="368"/>
-        <source>Third-length center grooved pins</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="369"/>
-        <source>Half-length center grooved pins</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="370"/>
-        <source>Full-length taper grooved pins</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="371"/>
-        <source>Half-length taper grooved pins</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="372"/>
-        <source>Grooved pins with round head</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="373"/>
-        <source>Grooved pins with countersunk head</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="374"/>
-        <source>Coiled spring pins, heavy duty</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="375"/>
-        <source>Coiled spring pins, standard duty</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="376"/>
-        <source>Coiled spring pins, light duty</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="377"/>
-        <source>Slotted spring pins, heavy duty</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="378"/>
-        <source>Slotted spring pins, light duty</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="490"/>
-        <source>Fastener type</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="511"/>
-        <source>Standard diameter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="523"/>
-        <source>Generate real thread</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="526"/>
-        <source>Left handed thread</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="529"/>
-        <source>Match outer thread diameter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="534"/>
-        <source>Body width code</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="557"/>
-        <source>Custom length</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="549"/>
-        <location filename="../FastenersCmd.py" line="562"/>
-        <source>Screw length</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../FastenersCmd.py" line="322"/>
+        <location filename="../../FastenersCmd.py" line="322"/>
         <source>Metric threaded rod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="565"/>
+        <location filename="../../FastenersCmd.py" line="323"/>
+        <source>Metric threaded rod for tapping holes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="324"/>
+        <source>Tool object to cut external metric threads</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="328"/>
+        <source>IUT[A/B/C] Heat Staked Metric Insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="329"/>
+        <source>PEM Self Clinching nut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="330"/>
+        <source>PEM Self Clinching standoff</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="331"/>
+        <source>PEM Self Clinching stud</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="332"/>
+        <source>Wurth WA-SSTII PCB spacer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="333"/>
+        <source>Wurth WA-SSTII  PCB standoff</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="334"/>
+        <source>4 Prong Wood Thread Insert (DIN 1624 Tee nuts)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="338"/>
+        <source>Metric external retaining rings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="339"/>
+        <source>Metric internal retaining rings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="340"/>
+        <source>Metric E-clip retaining rings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="344"/>
+        <source>Round plain head nails for use in automatic nailing machines</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="345"/>
+        <source>Nails for the installation of wood wool composite panels, 20mm round head</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="346"/>
+        <source>Round plain head wire nails</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="347"/>
+        <source>Round countersunk head wire nails</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="348"/>
+        <source>Round lost head wire nails</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="349"/>
+        <source>Clout or slate nails</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="350"/>
+        <source>Clout or slate wide head nails</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="353"/>
+        <source>Split pins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="354"/>
+        <source>Parallel pins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="355"/>
+        <source>Taper pins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="356"/>
+        <source>Clevis pins without head</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="357"/>
+        <source>Clevis pins without head (with split pin holes)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="358"/>
+        <source>Clevis pins with head</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="359"/>
+        <source>Clevis pins with head (with split pin hole)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="360"/>
+        <source>Parallel pins with internal thread, unhardened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="361"/>
+        <source>Dowel pins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="362"/>
+        <source>Parallel pins with internal thread, hardened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="363"/>
+        <source>Taper pins with internal thread, unhardened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="364"/>
+        <source>Taper pins with external thread, unhardened</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="365"/>
+        <source>Full-length grooved pins with pilot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="366"/>
+        <source>Full-length grooved pins with chamfer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="367"/>
+        <source>Half-length reverse taper grooved pins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="368"/>
+        <source>Third-length center grooved pins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="369"/>
+        <source>Half-length center grooved pins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="370"/>
+        <source>Full-length taper grooved pins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="371"/>
+        <source>Half-length taper grooved pins</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="372"/>
+        <source>Grooved pins with round head</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="373"/>
+        <source>Grooved pins with countersunk head</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="374"/>
+        <source>Coiled spring pins, heavy duty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="375"/>
+        <source>Coiled spring pins, standard duty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="376"/>
+        <source>Coiled spring pins, light duty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="377"/>
+        <source>Slotted spring pins, heavy duty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="378"/>
+        <source>Slotted spring pins, light duty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="490"/>
+        <source>Fastener type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="511"/>
+        <source>Standard diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="523"/>
+        <source>Generate real thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="526"/>
+        <source>Left handed thread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="529"/>
+        <source>Match outer thread diameter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="534"/>
+        <source>Body width code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="549"/>
+        <location filename="../../FastenersCmd.py" line="562"/>
+        <source>Screw length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="557"/>
+        <source>Custom length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../FastenersCmd.py" line="565"/>
         <source>External Diameter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="568"/>
+        <location filename="../../FastenersCmd.py" line="568"/>
         <source>Screw major diameter custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="571"/>
+        <location filename="../../FastenersCmd.py" line="571"/>
         <source>Screw pitch custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="576"/>
+        <location filename="../../FastenersCmd.py" line="576"/>
         <source>Thickness code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="581"/>
+        <location filename="../../FastenersCmd.py" line="581"/>
         <source>Slot width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="586"/>
+        <location filename="../../FastenersCmd.py" line="586"/>
         <source>Key size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="591"/>
+        <location filename="../../FastenersCmd.py" line="591"/>
         <source>Blind Standoff type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="594"/>
+        <location filename="../../FastenersCmd.py" line="594"/>
         <source>Threaded part length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="877"/>
+        <location filename="../../FastenersCmd.py" line="877"/>
         <source>Add </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1511,92 +1552,92 @@
 <context>
     <name>FastenerCmdTreeView</name>
     <message>
-        <location filename="../FastenersCmd.py" line="43"/>
+        <location filename="../../FastenersCmd.py" line="43"/>
         <source>Screw</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="44"/>
+        <location filename="../../FastenersCmd.py" line="44"/>
         <source>Washer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="45"/>
+        <location filename="../../FastenersCmd.py" line="45"/>
         <source>Nut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="46"/>
+        <location filename="../../FastenersCmd.py" line="46"/>
         <source>ThreadedRod</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="47"/>
+        <location filename="../../FastenersCmd.py" line="47"/>
         <source>PressNut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="48"/>
+        <location filename="../../FastenersCmd.py" line="48"/>
         <source>Standoff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="49"/>
+        <location filename="../../FastenersCmd.py" line="49"/>
         <source>Spacer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="50"/>
+        <location filename="../../FastenersCmd.py" line="50"/>
         <source>Stud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="51"/>
+        <location filename="../../FastenersCmd.py" line="51"/>
         <source>ScrewTap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="52"/>
+        <location filename="../../FastenersCmd.py" line="52"/>
         <source>ScrewDie</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="53"/>
+        <location filename="../../FastenersCmd.py" line="53"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="54"/>
+        <location filename="../../FastenersCmd.py" line="54"/>
         <source>RetainingRing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="55"/>
+        <location filename="../../FastenersCmd.py" line="55"/>
         <source>T-Slot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="56"/>
+        <location filename="../../FastenersCmd.py" line="56"/>
         <source>SetScrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="57"/>
+        <location filename="../../FastenersCmd.py" line="57"/>
         <source>HexKey</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="58"/>
+        <location filename="../../FastenersCmd.py" line="58"/>
         <source>Nail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="59"/>
+        <location filename="../../FastenersCmd.py" line="59"/>
         <source>Pin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FastenersCmd.py" line="62"/>
+        <location filename="../../FastenersCmd.py" line="62"/>
         <source>Thumbscrew</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1604,7 +1645,7 @@
 <context>
     <name>Fastenerbase</name>
     <message>
-        <location filename="../FastenerBase.py" line="1005"/>
+        <location filename="../../FastenerBase.py" line="1009"/>
         <source> Pin </source>
         <translation type="unfinished"></translation>
     </message>
@@ -1612,7 +1653,7 @@
 <context>
     <name>Fasteners</name>
     <message>
-        <location filename="../CountersunkHoles.py" line="248"/>
+        <location filename="../../CountersunkHoles.py" line="248"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1620,155 +1661,155 @@
 <context>
     <name>ViewSetLineWidth</name>
     <message>
-        <location filename="../FSprefs.ui" line="14"/>
+        <location filename="../../FSprefs.ui" line="14"/>
         <source>General settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="20"/>
+        <location filename="../../FSprefs.ui" line="20"/>
         <source>Fastener standards shown in toolbars:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="31"/>
+        <location filename="../../FSprefs.ui" line="31"/>
         <source>ASME</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="50"/>
+        <location filename="../../FSprefs.ui" line="50"/>
         <source>DIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="69"/>
+        <location filename="../../FSprefs.ui" line="69"/>
         <source>EN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="105"/>
+        <location filename="../../FSprefs.ui" line="105"/>
         <source>GOST</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="124"/>
+        <location filename="../../FSprefs.ui" line="124"/>
         <source>ISO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="143"/>
+        <location filename="../../FSprefs.ui" line="143"/>
         <source>SAE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="182"/>
+        <location filename="../../FSprefs.ui" line="182"/>
         <source>Preferences for the Fasteners Workbench</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="189"/>
+        <location filename="../../FSprefs.ui" line="189"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="200"/>
+        <location filename="../../FSprefs.ui" line="200"/>
         <source>Set default fastener color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="255"/>
+        <location filename="../../FSprefs.ui" line="255"/>
         <source>Set default line width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="312"/>
-        <location filename="../FSprefs.ui" line="383"/>
+        <location filename="../../FSprefs.ui" line="312"/>
+        <location filename="../../FSprefs.ui" line="383"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="326"/>
+        <location filename="../../FSprefs.ui" line="326"/>
         <source>Set default point size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="395"/>
+        <location filename="../../FSprefs.ui" line="395"/>
         <source>Scale settings for 3D printing thread generation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="409"/>
+        <location filename="../../FSprefs.ui" line="409"/>
         <source>Screw Scaling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="417"/>
-        <location filename="../FSprefs.ui" line="498"/>
+        <location filename="../../FSprefs.ui" line="417"/>
+        <location filename="../../FSprefs.ui" line="498"/>
         <source>Scale (A):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="453"/>
-        <location filename="../FSprefs.ui" line="534"/>
+        <location filename="../../FSprefs.ui" line="453"/>
+        <location filename="../../FSprefs.ui" line="534"/>
         <source>Offset (B):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="490"/>
+        <location filename="../../FSprefs.ui" line="490"/>
         <source>Nut Scaling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="575"/>
+        <location filename="../../FSprefs.ui" line="575"/>
         <source>* Thread&apos;s newDiam = oldDiam * A + B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="593"/>
+        <location filename="../../FSprefs.ui" line="593"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="604"/>
+        <location filename="../../FSprefs.ui" line="604"/>
         <source>Toolbar screw icons grouping:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="624"/>
+        <location filename="../../FSprefs.ui" line="624"/>
         <source>Method of icon grouping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="637"/>
+        <location filename="../../FSprefs.ui" line="637"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="642"/>
+        <location filename="../../FSprefs.ui" line="642"/>
         <source>Separate toolbars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="647"/>
+        <location filename="../../FSprefs.ui" line="647"/>
         <source>Drop down buttons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="659"/>
+        <location filename="../../FSprefs.ui" line="659"/>
         <source>Thread generation:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="679"/>
+        <location filename="../../FSprefs.ui" line="679"/>
         <source>Select method of thread generation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="689"/>
+        <location filename="../../FSprefs.ui" line="689"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../FSprefs.ui" line="694"/>
+        <location filename="../../FSprefs.ui" line="694"/>
         <source>3D printer compatible</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1776,46 +1817,46 @@
 <context>
     <name>Workbench</name>
     <message>
-        <location filename="../InitGui.py" line="38"/>
-        <location filename="../InitGui.py" line="56"/>
-        <location filename="../InitGui.py" line="67"/>
-        <location filename="../InitGui.py" line="84"/>
-        <location filename="../InitGui.py" line="123"/>
+        <location filename="../../InitGui.py" line="38"/>
+        <location filename="../../InitGui.py" line="56"/>
+        <location filename="../../InitGui.py" line="67"/>
+        <location filename="../../InitGui.py" line="84"/>
+        <location filename="../../InitGui.py" line="123"/>
         <source>Fasteners</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../InitGui.py" line="39"/>
+        <location filename="../../InitGui.py" line="39"/>
         <source>Create ISO Fasteners</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../InitGui.py" line="54"/>
+        <location filename="../../InitGui.py" line="54"/>
         <source>FS Commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../InitGui.py" line="70"/>
+        <location filename="../../InitGui.py" line="70"/>
         <source>Add Other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../InitGui.py" line="76"/>
+        <location filename="../../InitGui.py" line="76"/>
         <source>Add </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../InitGui.py" line="85"/>
+        <location filename="../../InitGui.py" line="85"/>
         <source>Add Fasteners</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../InitGui.py" line="88"/>
+        <location filename="../../InitGui.py" line="88"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../InitGui.py" line="102"/>
+        <location filename="../../InitGui.py" line="102"/>
         <source>FS Screws</source>
         <translation type="unfinished"></translation>
     </message>

--- a/Resources/translations/update_translation.sh
+++ b/Resources/translations/update_translation.sh
@@ -69,13 +69,13 @@ update_locale() {
 
 	# NOTE: Execute the right commands depending on:
 	# - if it's a locale file or the main, agnostic one
-	[ ! -f "${WB}${u}${locale}.ts" ] && action="Creating" || action="Updating"
-	echo -e "\033[1;34m\n\t<<< ${action} '${WB}${u}${locale}.ts' file >>>\n\033[m"
+	[ ! -f "${WB}${u}${locale,,}.ts" ] && action="Creating" || action="Updating"
+	echo -e "\033[1;34m\n\t<<< ${action} '${WB}${u}${locale,,}.ts' file >>>\n\033[m"
 	if [ "$u" == "" ]; then
 		eval $LUPDATE "$FILES" -ts "${WB}.ts" # locale-agnostic file
 	else
 		eval $LUPDATE "$FILES" -source-language en_US -target-language "${locale//-/_}" \
-			-ts "${WB}_${locale}.ts"
+			-ts "${WB}_${locale,,}.ts" -no-obsolete
 	fi
 }
 
@@ -85,8 +85,8 @@ help() {
 	echo -e "\nUsage:"
 	echo -e "\t./update_translation.sh [-R] [-U] [-r <locale>] [-u <locale>]"
 	echo -e "\nFlags:"
-	echo -e "  -R\n\tRelease all locales"
-	echo -e "  -U\n\tUpdate main translation file (locale agnostic)"
+	echo -e "  -R\n\tRelease all translations (qm files)"
+	echo -e "  -U\n\tUpdate all translations (ts files)"
 	echo -e "  -r <locale>\n\tRelease the specified locale"
 	echo -e "  -u <locale>\n\tUpdate strings for the specified locale"
 }
@@ -99,12 +99,10 @@ LRELEASE=/usr/lib/qt6/bin/lrelease # from Qt6
 # LRELEASE=lrelease                 # from Qt5
 WB="fasteners"
 
-# Enforce underscore on locales
-sed -i '3s/-/_/' ${WB}*.ts
+sed -i '3s/-/_/' ${WB}*.ts               # Enforce underscore on locales
+sed -i '3s/\"en\"/\"en_US\"/g' ${WB}*.ts # Use en_US
 
-if [ $# -eq 0 ]; then
-	help
-elif [ $# -eq 1 ]; then
+if [ $# -eq 1 ]; then
 	if [ "$1" == "-R" ]; then
 		find . -type f -name '*_*.ts' | while IFS= read -r file; do
 			# Release all locales
@@ -112,8 +110,11 @@ elif [ $# -eq 1 ]; then
 			echo
 		done
 	elif [ "$1" == "-U" ]; then
-		# Update main file (agnostic)
-		update_locale
+		for locale in "${supported_locales[@]}"; do
+			update_locale "$locale"
+		done
+	elif [ "$1" == "-u" ]; then
+		update_locale # Update main file (agnostic)
 	else
 		help
 	fi
@@ -122,7 +123,7 @@ elif [ $# -eq 2 ]; then
 	if is_locale_supported "$LOCALE"; then
 		if [ "$1" == "-r" ]; then
 			# Release locale (creation of *.qm file from *.ts file)
-			$LRELEASE -nounfinished "${WB}_${LOCALE,,}.ts"
+			$LRELEASE -nounfinished "${WB}_${LOCALE}.ts"
 		elif [ "$1" == "-u" ]; then
 			# Update main & locale files
 			update_locale
@@ -131,7 +132,7 @@ elif [ $# -eq 2 ]; then
 	else
 		echo "Verify your language code. Case sensitive."
 		echo "If it's correct, ask a maintainer to add support for your language on FreeCAD."
-		echo -e "Supported locales, '\033[1;34mFreeCADGui.supportedLocales()\033[m': \033[1;33m"
+		echo -e "\nSupported locales, '\033[1;34mFreeCADGui.supportedLocales()\033[m': \033[1;33m"
 		for locale in $(printf "%s\n" "${supported_locales[@]}" | sort); do
 			echo -n "$locale "
 		done

--- a/screw_maker.py
+++ b/screw_maker.py
@@ -258,7 +258,7 @@ class Screw:
         - P: thread pitch
         - blen: thread length. The actual returned shape will be slightly
           longer, to ensure that a thread of the specified length can be
-          cut without errors at it's ends
+          cut without errors at its ends
 
         The shape is created at the origin, extending in the -Z direction.
         """
@@ -372,7 +372,7 @@ class Screw:
         - P: thread pitch
         - blen: thread length. The actual returned shape will be slightly
           longer, to ensure that a thread of the specified length can be
-          cut without errors at it's ends
+          cut without errors at its ends
 
         The shape is created at the origin, extending in the -Z direction.
         It has a tapered lead out at the top of the shape, to simulate the


### PR DESCRIPTION
Hi @maxe22 did you detected other missing strings?

TODO:
- [ ] tweak code to allow bigger drop-down and prevent text shortened
![image](https://github.com/user-attachments/assets/3f14beb5-6307-4635-ae60-f3394bf4e049)


Fix #418 