### PR TITLE
Issue #437 (ScrewTap length) bug correction

### DIFF
--- a/FastenersCmd.py
+++ b/FastenersCmd.py
@@ -698,7 +698,7 @@ class FSScrewObject(FSBaseObject):
                     minimumLength = Units.Quantity(FSParam.GetString("MinimumLength", "2.0 mm"))
                 except ValueError:
                     minimumLength = Units.Quantity("2.0 mm")
-                if Units.Quantity(l).UserString < minimumLength.UserString:
+                if Units.Quantity(l) < minimumLength.getValueAs(1.0,1):
                     l = minimumLength.getValueAs(1.0,1)
                 fp.Length = l
                 self.calc_len = str(l)


### PR DESCRIPTION
The new code for adding minimum length option in preferences add a test between 2 values, but the test use string comparison in place of numeric comparison !
Correction is using numeric values for the test.