### PR TITLE
Fix weld nut displacement caused by #441

### DIFF
--- a/FsFunctions/FSmakeWeldNut.py
+++ b/FsFunctions/FSmakeWeldNut.py
@@ -98,8 +98,9 @@ def _makeHexWeldNut(self, fa):
     # transform so that the XY-plane relates better to the installed height
     mat = Base.Matrix()
     mat.move(Base.Vector(0.0, 0.0, -h1))
-    shape = shape.transformShape(mat)
-    return shape
+    shape = shape.SubShapes[0]
+    shape.transformShape(mat)
+    return Part.Compound([shape])
 
 
 def _makeFlangedWeldNut(self, fa):
@@ -211,5 +212,6 @@ def _makeSquareWeldNut(self, fa):
     # transform so that the XY-plane relates better to the installed height
     mat = Base.Matrix()
     mat.move(Base.Vector(0.0, 0.0, -h1))
-    shape = shape.transformShape(mat)
-    return shape
+    shape = shape.SubShapes[0]
+    shape.transformShape(mat)
+    return Part.Compound([shape])


### PR DESCRIPTION
Something went wrong at my end, sorry about that.

To preserve the effect of transformShape (see #441) the subshape should be modified and a new compound created.