### PR TITLE
Update icon path in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
   <license file="LICENSE">GPL-2.0-or-later</license>
   <url type="repository" branch="master">https://github.com/shaise/FreeCAD_FastenersWB</url>
   <url type="readme">https://github.com/shaise/FreeCAD_FastenersWB/blob/master/README.md</url>
-  <icon>Resources/Icons/FNLogo.svg</icon>
+  <icon>Icons/FNLogo.svg</icon>
 
   <content>
     <workbench>


### PR DESCRIPTION
The icon file is not (any longer) in the Resources subdirectory.